### PR TITLE
chore: express-async-handler 삭제

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^5.0.0",
-    "express-async-handler": "^1.2.0",
     "http-status-codes": "^2.3.0",
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^3.0.1",

--- a/src/routers/memo.router.ts
+++ b/src/routers/memo.router.ts
@@ -1,10 +1,9 @@
 import express from 'express';
 export const memoFolderRouter = express.Router();
-import expressAsyncHandler from 'express-async-handler';
 import { handlerMemoFolderAdd, handlerMemoFolderImageCreate } from '../controllers/memo-folder.controller.js';
 import { imageUploader } from '../s3/image.uploader.js';
 import { handlerMemoImageAdd } from '../controllers/memo-image.controller.js';
 
-memoFolderRouter.post('/folders', expressAsyncHandler(handlerMemoFolderAdd));
-memoFolderRouter.post('/image-format/folders', imageUploader.single('image'), expressAsyncHandler(handlerMemoFolderImageCreate));
-memoFolderRouter.post('/image-format/folders/:folderId', imageUploader.single('image'), expressAsyncHandler(handlerMemoImageAdd));
+memoFolderRouter.post('/folders', handlerMemoFolderAdd);
+memoFolderRouter.post('/image-format/folders', imageUploader.single('image'), handlerMemoFolderImageCreate);
+memoFolderRouter.post('/image-format/folders/:folderId', imageUploader.single('image'), handlerMemoImageAdd);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3266,11 +3266,6 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-express-async-handler@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/express-async-handler/-/express-async-handler-1.2.0.tgz#ffc9896061d90f8d2e71a2d2b8668db5b0934391"
-  integrity sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w==
-
 express@^4.21.2:
   version "4.21.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"


### PR DESCRIPTION
express-async-handler 삭제 (express 버전 5.0 이상부터는 async-handler를 쓰지 않아도 자체적으로 에러 감지 가능)