### PR TITLE
[SWEP-51] Session 테이블 수정 및 마이그레이션 추가

### DIFF
--- a/prisma/migrations/20250121060755_session_table_update/migration.sql
+++ b/prisma/migrations/20250121060755_session_table_update/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `user_id` on the `session` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[sid]` on the table `session` will be added. If there are existing duplicate values, this will fail.
+  - Made the column `expires_at` on table `session` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE `session` DROP FOREIGN KEY `session_user_id_fkey`;
+
+-- DropIndex
+DROP INDEX `session_user_id_fkey` ON `session`;
+
+-- AlterTable
+ALTER TABLE `session` DROP COLUMN `user_id`,
+    MODIFY `expires_at` TIMESTAMP(3) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `session_sid_key` ON `session`(`sid`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,6 @@ model User {
   updatedAt DateTime? @db.Timestamp(6) @updatedAt @map("updated_at")
   status Int @db.TinyInt @default(1)
 
-  sessions Session[]
   socialAccounts SocialAccount[]
   notification Notification?
   images Image[]
@@ -62,12 +61,10 @@ model Notification {
 
 model Session {
   id String @id @db.VarChar(255)
-  sid String @db.VarChar(255)
+  sid String @unique @db.VarChar(255)
   data String @db.VarChar(512)
-  expiresAt DateTime? @db.Timestamp(3) @map("expires_at")
+  expiresAt DateTime @db.Timestamp(3) @map("expires_at")
   
-  userId BigInt @map("user_id")
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
   @@map("session")
 }
 


### PR DESCRIPTION
# Sweepic Server PR List
close #55 

## ⚒️develop의 최신 커밋을 pull 받았나요?
- [x] 최신 커밋 업데이트

## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
* 로그인 기능 추가시 Session에서 타입이 맞지않아 발생 하는 오류 해결
  schema.prisma에서 정의한 Session 모델과 @quixo/prisma-session-store 모듈의  PrismaSessionStore() 생성자에서 요구하는 Session에 대한 모델이 달라서 타입오류가 발생

  <img width="365" alt="image" src="https://github.com/user-attachments/assets/18ff1b98-ed4d-41b6-9746-0e0cc54599b8" />
  <img width="1007" alt="image" src="https://github.com/user-attachments/assets/4c32ec24-4404-4828-a5ba-7237d972b6a8" />


## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요? (핵심 작업 내용)
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* schema.prisma에서 Session 모델 수정
  <img width="329" alt="image" src="https://github.com/user-attachments/assets/979c489e-7065-4861-8966-cd698da81dc0" />
  - 기존의 sid에 없었던 @unique 어노테이션 추가
  - Session의 모든 칼럼을 not null로 설정
  - user와의 연결성 해제

* schema.prisma에서 User 모델 수정
  <img width="419" alt="image" src="https://github.com/user-attachments/assets/a6269435-a33c-4a30-b055-9c07c388e602" />
  - 기존에 있었던 session Session[] 부분을 제거(Session과 User와의 외래키로 연결된 부분 삭제)
  - Session 테이블은 다른 테이블과 아무런 연관관계 없이 단독으로 유지됨

* 위와 같이 바꾼 이유는 @quixo3/prisma-session-store를 이용하려면 아래와 같이 Session 테이블의 형태를 유지해줘야 타입에러가 발생하지 않음
  <img width="544" alt="image" src="https://github.com/user-attachments/assets/91264146-f9f2-4c9e-a1ea-c63a4a58f6bf" />
  아래는 공식문서에서의 내용입니다.
  https://www.npmjs.com/package/@quixo3/prisma-session-store

  예를 들어
  <img width="335" alt="image" src="https://github.com/user-attachments/assets/63e72677-1773-4442-8c74-2c39c8fa8310" />
  공식문서상에는 sid에 @unique 어노테이션 들어가있지만 안들어간 상태로 만들경우
  yarn prisma generate를 통해 prisma client를 만들때
  여기서 만들어진 Session의 타입으로 prisma client의 타입을 정의 하게되고
  이러한 타입의 정의는 node_modules/.prisma/client/index.d.ts 에 생성된다.
  
  <img width="328" alt="image" src="https://github.com/user-attachments/assets/fa4979d2-3c42-4cda-8f88-012d01625f7f" />
  
  위의 사진처럼 node_modules/.prisma/client/index.d.ts 파일 안에 
  Prisma에 의해 자동 생성된 타입인 SessionWhereUniqueInput 이라는 타입이 정의 되어있는데 
  prisma-session-store에서 요구하는 건 sid?: string 인데 자동생성된 prisma client는 sid?: StringFilter<"Session"> | string 이렇게 정의가 되어있다.
  
  그러나 @unique 어노테이션을 넣으면
  <img width="326" alt="image" src="https://github.com/user-attachments/assets/3d7ebabb-7486-4daf-b9c4-3b18f9da2cf6" />
  다음과 같이 sid?: string으로 타입이 되어있기 때문에 이는 prisma-sesssion-store가 요구하는 타입과 맞아 
  yarn compile을 통과하게 된다.

  이처럼 공식문서가 요구하는 Session 모델과 다를 경우 타입에러가 발생하며
  이를 막기위해 schema.prisma의 session 모델을 수정했다.


## 🤚 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스크린 샷을 올려주세요
* yarn compile 확인
  <img width="106" alt="image" src="https://github.com/user-attachments/assets/a0c32a6c-cd04-493d-8059-60eb1eff70cb" />


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* migration 진행을 위해 migrations 에 변경사항 추가

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
* 현재 마이그레이션은 저의 로컬에서 적용하였고 모든 리뷰어들이 승인을 하면 해당 마이그레이션 내용을 RDS에 deploy 하겠습니다! 

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
*

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **2일 이내**에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [x] To-Do Item
