### PR TITLE
[SWEP-50] 메모장 조회 API 구현

### DIFF
--- a/src/controllers/memo-folder.controller.ts
+++ b/src/controllers/memo-folder.controller.ts
@@ -143,6 +143,7 @@ export const handlerMemoFolderList = async (req: Request, res: Response, next: N
                                             folderId: { type: "string", example: "1" },
                                             folderName: { type: "string" },
                                             imageText: { type: "string" },
+                                            imageCount: { type: "integer", example: 0 },
                                             firstImageId: { type: "string", example: "1" },
                                             firstImageUrl: { type: "string" },
                                             createdAt: { type: "string", example: "2025-01-17T03:50:25.923Z"}
@@ -198,6 +199,7 @@ export const handlerMemoSearch = async (req: Request, res: Response, next: NextF
                                         properties: {
                                             folderId: { type: "string", example: "1" },
                                             folderName: { type: "string" },
+                                            imageCount: { type: "integer", example: 0 },
                                             imageText: { type: "string" },
                                             firstImageId: { type: "string", example: "1" },
                                             firstImageUrl: { type: "string" },

--- a/src/controllers/memo-folder.controller.ts
+++ b/src/controllers/memo-folder.controller.ts
@@ -1,7 +1,7 @@
 import { Response, Request, NextFunction } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { bodyToMemoFolder } from '../dtos/memo-folder.dto.js';
-import { memoFolderCreate, memoFolderImageCreate } from '../services/memo-folder.service.js';
+import { listMemoFolder, listMemoTextImage, memoFolderCreate, memoFolderImageCreate, memoSearch } from '../services/memo-folder.service.js';
 
 export const handlerMemoFolderImageCreate = async (req: Request, res: Response, next: NextFunction) => {
     /*
@@ -58,7 +58,7 @@ export const handlerMemoFolderImageCreate = async (req: Request, res: Response, 
     //     throw new Error('로그인을 하지 않았습니다.');
     // }
     if (!req.file) {
-        throw new Error('첨부한 사진이 없습니다.');
+        throw new Error('저장할 사진이 없습니다.');
     }
     const imageUrl = (req.file as Express.MulterS3File).key;
     const folderId = req.uploadDirectory;
@@ -116,4 +116,170 @@ export const handlerMemoFolderAdd = async (req: Request, res: Response, next: Ne
     const userId = BigInt(1); //BigInt(req.user!.id);
     const memoFolder = await memoFolderCreate(userId, bodyToMemoFolder(req.body));
     res.status(StatusCodes.OK).success(memoFolder);
+};
+
+export const handlerMemoFolderList = async (req: Request, res: Response, next: NextFunction) => {
+    /*
+    #swagger.tags = ['memo-folder-controller']
+    #swagger.summary = '모든 메모 조회 API';
+    #swagger.description = '모든 메모를 조회하는 API입니다.'
+    #swagger.responses[200] = {
+        description: "메모 조회 성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "SUCCESS" },
+                        error: { type: "object", nullable: true, example: null },
+                        success: {
+                            type: "object", 
+                            properties: {
+                                data: {
+                                    type: "array",
+                                    items: {
+                                        type: "object", 
+                                        properties: {
+                                            folderId: { type: "string", example: "1" },
+                                            folderName: { type: "string" },
+                                            imageText: { type: "string" },
+                                            firstImageId: { type: "string", example: "1" },
+                                            firstImageUrl: { type: "string" },
+                                            createdAt: { type: "string", example: "2025-01-17T03:50:25.923Z"}
+                                        }
+                                    }
+                                }    
+                            }
+                        }   
+                    }
+                }
+            }
+        }
+    };
+    */
+    console.log('메모 폴더 리스트 조회');
+    // if (!req.user) {
+    //     throw new Error('로그인을 하지 않았습니다.');
+    // }
+    const userId = BigInt(1); //BigInt(req.user!.id);
+    const memoList = await listMemoFolder(userId);
+    res.status(StatusCodes.OK).success(memoList);
+};
+
+export const handlerMemoSearch = async (req: Request, res: Response, next: NextFunction) => {
+    /*
+    #swagger.tags = ['memo-folder-controller']
+    #swagger.summary = '메모 검색 API';
+    #swagger.description = '메모를 검색 및 조회하는 API입니다.'
+    #swagger.parameters['keyword'] = {
+        in: 'query',
+        required: true,
+        description: "검색 키워드",
+        '@schema': {
+            type: "string",
+        }
+    };
+    #swagger.responses[200] = {
+        description: "메모 검색 성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "SUCCESS" },
+                        error: { type: "object", nullable: true, example: null },
+                        success: {
+                            type: "object", 
+                            properties: {
+                                data: {
+                                    type: "array",
+                                    items: {
+                                        type: "object", 
+                                        properties: {
+                                            folderId: { type: "string", example: "1" },
+                                            folderName: { type: "string" },
+                                            imageText: { type: "string" },
+                                            firstImageId: { type: "string", example: "1" },
+                                            firstImageUrl: { type: "string" },
+                                            createdAt: { type: "string", example: "2025-01-17T03:50:25.923Z"}
+                                        }
+                                    }
+                                }    
+                            }
+                        }   
+                    }
+                }
+            }
+        }
+    };
+    */
+    console.log('메모 검색');
+    // if (!req.user) {
+    //     throw new Error('로그인을 하지 않았습니다.');
+    // }
+    const userId = BigInt(1); //BigInt(req.user!.id);
+    const searchKeyword = req.query.keyword?.toString();
+    if (searchKeyword == null) {
+        throw new Error('검색어를 1자 이상 입력하세요.');
+    }
+    const searchMemoList = await memoSearch(userId, searchKeyword);
+    res.status(StatusCodes.OK).success(searchMemoList);
+};
+
+export const handlerMemoTextImageList = async (req: Request, res: Response, next: NextFunction) => {
+    /*
+    #swagger.tags = ['memo-folder-controller']
+    #swagger.summary = '특정 폴더의 메모 조회 API';
+    #swagger.description = '특정 폴더의 모든 메모(텍스트 및 사진)을 조회하는 API입니다.'
+    #swagger.parameters['folderId'] = {
+        in: 'path',
+        required: true,
+        description: "폴더 ID 입력",
+        '@schema': {
+            type: "integer",
+            format: "int64"
+        }
+    };
+    #swagger.responses[200] = {
+        description: "메모 조회 성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "SUCCESS" },
+                        error: { type: "object", nullable: true, example: null },
+                        success: {
+                            type: "object", 
+                            properties: {
+                                folderId: { type: "string", example: "1" },
+                                folderName: { type: "string" },
+                                imageText: { type: "string" },
+                                images: { 
+                                    type: "array", 
+                                    items: { 
+                                        type: "object", 
+                                        properties: { 
+                                            imageId: {type: "string", example: "1"}, 
+                                            imageUrl: {type: "string" }
+                                        }
+                                    }
+                                },
+                                createdAt: { type: "string", example: "2025-01-17T03:50:25.923Z"}
+                            }
+                        }     
+                    }
+                }
+            }
+        }
+    };
+    */
+    console.log('특정 폴더의 사진&텍스트 리스트 조회');
+    // if (!req.user) {
+    //     throw new Error('로그인을 하지 않았습니다.');
+    // }
+    const userId = BigInt(1);//BigInt(req.user!.id);
+    const folderId = BigInt(req.params.folderId);
+    const memoTextImageList = await listMemoTextImage(userId, folderId);
+    res.status(StatusCodes.OK).success(memoTextImageList);
 };

--- a/src/controllers/memo-folder.controller.ts
+++ b/src/controllers/memo-folder.controller.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { bodyToMemoFolder } from '../dtos/memo-folder.dto.js';
 import { listMemoFolder, listMemoTextImage, memoFolderCreate, memoFolderImageCreate, memoSearch } from '../services/memo-folder.service.js';
 
-export const handlerMemoFolderImageCreate = async (req: Request, res: Response, next: NextFunction) => {
+export const handlerMemoFolderImageCreate = async (req: Request, res: Response, next: NextFunction): Promise<void> =>{
     /*
     #swagger.tags = ['memo-folder-controller']
     #swagger.summary = '폴더 생성 및 사진 저장 API';
@@ -67,7 +67,7 @@ export const handlerMemoFolderImageCreate = async (req: Request, res: Response, 
     res.status(StatusCodes.OK).success(memoFolderImage);
 };
 
-export const handlerMemoFolderAdd = async (req: Request, res: Response, next: NextFunction) => {
+export const handlerMemoFolderAdd = async (req: Request, res: Response, next: NextFunction): Promise<void> =>{
     /*
     #swagger.tags = ['memo-folder-controller']
     #swagger.summary = '폴더 생성 API';
@@ -118,7 +118,7 @@ export const handlerMemoFolderAdd = async (req: Request, res: Response, next: Ne
     res.status(StatusCodes.OK).success(memoFolder);
 };
 
-export const handlerMemoFolderList = async (req: Request, res: Response, next: NextFunction) => {
+export const handlerMemoFolderList = async (req: Request, res: Response, next: NextFunction): Promise<void> =>{
     /*
     #swagger.tags = ['memo-folder-controller']
     #swagger.summary = '모든 메모 조회 API';
@@ -167,7 +167,7 @@ export const handlerMemoFolderList = async (req: Request, res: Response, next: N
     res.status(StatusCodes.OK).success(memoList);
 };
 
-export const handlerMemoSearch = async (req: Request, res: Response, next: NextFunction) => {
+export const handlerMemoSearch = async (req: Request, res: Response, next: NextFunction): Promise<void> =>{
     /*
     #swagger.tags = ['memo-folder-controller']
     #swagger.summary = '메모 검색 API';
@@ -228,7 +228,7 @@ export const handlerMemoSearch = async (req: Request, res: Response, next: NextF
     res.status(StatusCodes.OK).success(searchMemoList);
 };
 
-export const handlerMemoTextImageList = async (req: Request, res: Response, next: NextFunction) => {
+export const handlerMemoTextImageList = async (req: Request, res: Response, next: NextFunction): Promise<void> =>{
     /*
     #swagger.tags = ['memo-folder-controller']
     #swagger.summary = '특정 폴더의 메모 조회 API';

--- a/src/controllers/memo-image.controller.ts
+++ b/src/controllers/memo-image.controller.ts
@@ -2,7 +2,7 @@ import { Response, Request, NextFunction } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { memoImageAdd } from '../services/memo-image.service.js';
 
-export const handlerMemoImageAdd = async (req: Request, res: Response, next: NextFunction) => {
+export const handlerMemoImageAdd = async (req: Request, res: Response, next: NextFunction): Promise<void> =>{
     /*
     #swagger.tags = ['memo-image-controller']
     #swagger.summary = '사진 저장 API';

--- a/src/controllers/memo-image.controller.ts
+++ b/src/controllers/memo-image.controller.ts
@@ -63,7 +63,10 @@ export const handlerMemoImageAdd = async (req: Request, res: Response, next: Nex
     //     throw new Error('로그인을 하지 않았습니다.');
     // }
     const folderId = BigInt(req.params.folderId);
-    const imageUrl = (req.file as any).key;
+    if (!req.file) {
+        throw new Error('저장할 사진이 없습니다.');
+    }
+    const imageUrl = (req.file as Express.MulterS3File).key;
     const memoImage = await memoImageAdd(folderId, imageUrl);
     res.status(StatusCodes.OK).success(memoImage);
 };

--- a/src/dtos/memo-folder.dto.ts
+++ b/src/dtos/memo-folder.dto.ts
@@ -1,4 +1,4 @@
-import { BodyToMemoFolder, ResponseFromMemo, ResponseFromMemoFolder } from '../models/memo-folder.model.js';
+import { BodyToMemoFolder, ResponseFromMemo, ResponseFromMemoFolder, ResponseFromMemoList } from '../models/memo-folder.model.js';
 import { ResponseFromMemoImage } from '../models/memo-image.model.js';
 
 export const bodyToMemoFolder = ({ folderName }: BodyToMemoFolder) => {
@@ -26,14 +26,15 @@ export const responseFromMemoFolderImage = ({ memoFolder: { id: folderId, name: 
     };
 };
 
-export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemo[]) => {
+export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemoList[]) => {
     return {
-        data: searchMemoList.map(({ id: folderId, name: folderName, imageText, memoImages }) => {
+        data: searchMemoList.map(({ id: folderId, name: folderName, imageCount, imageText, memoImages }) => {
             const [firstImage] = memoImages; // memoImages의 첫 번째 항목 구조 분해
             return {
                 folderId,
                 folderName,
                 imageText,
+                imageCount,
                 firstImageId: firstImage?.id || null, 
                 firstImageUrl: firstImage?.url || null, 
             };
@@ -41,12 +42,11 @@ export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemo[]) =
     };
 };
 
-export const responseFromMemoTextImageList = ({id, name, imageText, memoImages, createdAt}: ResponseFromMemo) => {
+export const responseFromMemoTextImageList = ({id, name, imageText, memoImages}: ResponseFromMemo) => {
     return {
         folderId: id,
         folderName: name,
         imageText,
         images: memoImages.length > 0 ? memoImages.map((mi) => ({ imageId: mi.id, imageUrl: mi.url })) : null,
-        createdAt,
     };
 };

--- a/src/dtos/memo-folder.dto.ts
+++ b/src/dtos/memo-folder.dto.ts
@@ -1,4 +1,4 @@
-import { BodyToMemoFolder, ResponseFromMemoFolder } from '../models/memo-folder.model.js';
+import { BodyToMemoFolder, ResponseFromMemo, ResponseFromMemoFolder } from '../models/memo-folder.model.js';
 import { ResponseFromMemoImage } from '../models/memo-image.model.js';
 
 export const bodyToMemoFolder = ({ folderName }: BodyToMemoFolder) => {
@@ -23,5 +23,30 @@ export const responseFromMemoFolderImage = ({ memoFolder: { id: folderId, name: 
         folderName,
         imageId,
         imageUrl
+    };
+};
+
+export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemo[]) => {
+    return {
+        data: searchMemoList.map(({ id: folderId, name: folderName, imageText, memoImages }) => {
+            const [firstImage] = memoImages; // memoImages의 첫 번째 항목 구조 분해
+            return {
+                folderId,
+                folderName,
+                imageText,
+                firstImageId: firstImage?.id || null, 
+                firstImageUrl: firstImage?.url || null, 
+            };
+        }),
+    };
+};
+
+export const responseFromMemoTextImageList = ({id, name, imageText, memoImages, createdAt}: ResponseFromMemo) => {
+    return {
+        folderId: id,
+        folderName: name,
+        imageText,
+        images: memoImages.length > 0 ? memoImages.map((mi) => ({ imageId: mi.id, imageUrl: mi.url })) : null,
+        createdAt,
     };
 };

--- a/src/dtos/memo-folder.dto.ts
+++ b/src/dtos/memo-folder.dto.ts
@@ -1,13 +1,13 @@
-import { BodyToMemoFolder, ResponseFromMemo, ResponseFromMemoFolder, ResponseFromMemoList } from '../models/memo-folder.model.js';
+import { BodyToMemoFolder, MemoFolderImageResponseDto, MemoFolderListResponseDto, MemoFolderRequestDto, MemoFolderResponseDto, MemoTextImageListResponseDto, ResponseFromMemo, ResponseFromMemoFolder, ResponseFromMemoList } from '../models/memo-folder.model.js';
 import { ResponseFromMemoImage } from '../models/memo-image.model.js';
 
-export const bodyToMemoFolder = ({ folderName }: BodyToMemoFolder) => {
+export const bodyToMemoFolder = ({ folderName }: BodyToMemoFolder): MemoFolderRequestDto => {
     return {
         folderName
     };
 };
 
-export const responseFromMemoFolder = ({ id, name }: ResponseFromMemoFolder) => {
+export const responseFromMemoFolder = ({ id, name }: ResponseFromMemoFolder): MemoFolderResponseDto => {
     return {
         id,
         folderName: name
@@ -17,7 +17,7 @@ export const responseFromMemoFolder = ({ id, name }: ResponseFromMemoFolder) => 
 export const responseFromMemoFolderImage = ({ memoFolder: { id: folderId, name: folderName }, memoImage: { id: imageId, url: imageUrl }}: {
     memoFolder: ResponseFromMemoFolder
     memoImage: ResponseFromMemoImage
-}) => {
+}): MemoFolderImageResponseDto => {
     return {
         folderId,
         folderName,
@@ -26,7 +26,7 @@ export const responseFromMemoFolderImage = ({ memoFolder: { id: folderId, name: 
     };
 };
 
-export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemoList[]) => {
+export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemoList[]):{ data: MemoFolderListResponseDto[] }=> {
     return {
         data: searchMemoList.map(({ id: folderId, name: folderName, imageCount, imageText, memoImages }) => {
             const [firstImage] = memoImages; // memoImages의 첫 번째 항목 구조 분해
@@ -42,7 +42,7 @@ export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemoList[
     };
 };
 
-export const responseFromMemoTextImageList = ({id, name, imageText, memoImages}: ResponseFromMemo) => {
+export const responseFromMemoTextImageList = ({id, name, imageText, memoImages}: ResponseFromMemo) : MemoTextImageListResponseDto => {
     return {
         folderId: id,
         folderName: name,

--- a/src/dtos/memo-image.dto.ts
+++ b/src/dtos/memo-image.dto.ts
@@ -1,6 +1,6 @@
-import { BodyToMemoImage } from '../models/memo-image.model.js';
+import { BodyToMemoImage, MemoImageRequestDto } from '../models/memo-image.model.js';
 
-export const bodyToMemoImage = ({url}: BodyToMemoImage) => {
+export const bodyToMemoImage = ({url}: BodyToMemoImage) : MemoImageRequestDto => {
     return {
         url
     };

--- a/src/models/memo-folder.model.ts
+++ b/src/models/memo-folder.model.ts
@@ -12,6 +12,41 @@ export interface ResponseFromMemoFolder {
     status: number;
 }
 
+export interface MemoFolderResponseDto {
+    id: string;
+    folderName: string;
+}
+
+export interface MemoFolderImageResponseDto {
+    folderId: string;
+    folderName: string;
+    imageId: string;
+    imageUrl: string;
+}
+
+export interface MemoFolderRequestDto {
+    folderName: string;
+}
+
+export interface MemoFolderListResponseDto {
+    folderId: string ;
+    folderName: string;
+    imageText: string;
+    imageCount: number;
+    firstImageId: string | null;
+    firstImageUrl: string | null;
+}
+
+export interface MemoTextImageListResponseDto {
+    folderId: string;
+    folderName: string;
+    imageText: string;
+    images: {
+        imageId: string;
+        imageUrl: string;
+    }[] | null;
+}
+
 export interface ResponseFromMemoFolderImage {
     id: string;
     userId: bigint;
@@ -59,20 +94,56 @@ export interface ResponseFromMemo {
     }[];
 }
 
-export interface ResponseFromMemo {
+export interface createdMemoFolderId {
+    id: bigint;
+}
+
+export interface MemoFoler {
     id: string;
-    userId: bigint;
     name: string;
     imageText: string;
     createdAt: Date;
     updatedAt: Date | null;
     status: number;
+    userId: bigint;
+}
+
+export interface MemoFolderList {
+    id: string;
+    imageCount: number;
     memoImages: {
         id: string;
+        folderId: string;
+        url: string;
         createdAt: Date;
         updatedAt: Date | null;
         status: number;
+    }[];
+    name: string;
+    imageText: string;
+    createdAt: Date;
+    updatedAt: Date | null;
+    status: number;
+    userId: bigint;
+    _count: {
+        memoImages: number;
+    };
+}
+
+export interface MemoTextImageList {
+    id: string;
+    memoImages: {
+        id: string;
         folderId: string;
         url: string;
+        createdAt: Date;
+        updatedAt: Date | null;
+        status: number;
     }[];
-}
+    name: string;
+    imageText: string;
+    createdAt: Date;
+    updatedAt: Date | null;
+    status: number;
+    userId: bigint;
+};

--- a/src/models/memo-folder.model.ts
+++ b/src/models/memo-folder.model.ts
@@ -39,3 +39,21 @@ export interface ResponseFromMemo {
         url: string;
     }[];
 }
+
+export interface ResponseFromMemo {
+    id: string;
+    userId: bigint;
+    name: string;
+    imageText: string;
+    createdAt: Date;
+    updatedAt: Date | null;
+    status: number;
+    memoImages: {
+        id: string;
+        createdAt: Date;
+        updatedAt: Date | null;
+        status: number;
+        folderId: string;
+        url: string;
+    }[];
+}

--- a/src/models/memo-folder.model.ts
+++ b/src/models/memo-folder.model.ts
@@ -22,6 +22,25 @@ export interface ResponseFromMemoFolderImage {
     status: number;
 }
 
+export interface ResponseFromMemoList {
+    id: string;
+    userId: bigint;
+    name: string;
+    imageText: string;
+    createdAt: Date;
+    updatedAt: Date | null;
+    status: number;
+    imageCount: number;
+    memoImages: {
+        id: string;
+        createdAt: Date;
+        updatedAt: Date | null;
+        status: number;
+        folderId: string;
+        url: string;
+    }[];
+};
+
 export interface ResponseFromMemo {
     id: string;
     userId: bigint;

--- a/src/models/memo-image.model.ts
+++ b/src/models/memo-image.model.ts
@@ -10,3 +10,16 @@ export interface ResponseFromMemoImage {
 export interface BodyToMemoImage {
     url: string;
 }
+
+export interface MemoImageRequestDto {
+    url: string;
+}
+
+export interface MemoImage {
+    id: string;
+    folderId: string;
+    url: string;
+    createdAt: Date;
+    updatedAt: Date | null;
+    status: number;
+}

--- a/src/repositories/memo-folder.repository.ts
+++ b/src/repositories/memo-folder.repository.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../db.config.js';
 import { BodyToMemoFolder } from '../models/memo-folder.model.js';
+import { getPresignedUrl } from '../s3/get-presigned-url.js';
 
 export const createMemoFolder = async (data: BodyToMemoFolder, userId: bigint) => {
     try {
@@ -45,6 +46,169 @@ export const getMemoFolder = async (memoFolderId: bigint) => {
         };
 
         return formattedMemoFolder;
+    }
+    catch (err) {
+        throw new Error('서버 내부 오류 또는 존재하지 않는 데이터');
+    }
+};
+
+export const getMemoFolderList = async (userId: bigint) => {
+    try {
+        const memoFolderList = await prisma.memoFolder.findMany({
+            select: {
+                id: true,
+                userId: true,
+                name: true,
+                imageText: true,
+                createdAt: true,
+                updatedAt: true,
+                status: true,
+                memoImages: {
+                    take: 1, // 각 폴더에서 첫 번째 사진만 가져오기
+                    orderBy: {
+                        createdAt: 'asc', // 업로드된 시간순으로 정렬
+                    },
+                },
+            },
+            where: {
+                userId: userId
+            }
+        });
+
+        const formattedMemoFolderList = await Promise.all( // 비동기 작업이 완료될 때까지 기다린 후 처리된 결과를 배열로 반환
+            memoFolderList.map(async (memoFolder) => ({
+                ...memoFolder,
+                id: memoFolder.id.toString(),
+                memoImages: await Promise.all(
+                    memoFolder.memoImages.map(async (memoImage) => {
+                        const presignedUrl = await getPresignedUrl(memoImage.url);
+                        return {
+                            ...memoImage,
+                            id: memoImage.id.toString(),
+                            folderId: memoImage.folderId.toString(),
+                            url: presignedUrl // Pre-signed URL로 변환
+                        };
+                    })
+                ),
+            }))
+        );
+
+        return formattedMemoFolderList;
+    }
+    catch (err) {
+        throw new Error('서버 내부 오류 또는 존재하지 않는 데이터');
+    }
+};
+
+export const getSearchMemoList = async (userId: bigint, searchKeyword: string) => {
+    try {
+        const memoSearchList = await prisma.memoFolder.findMany({
+            select: {
+                id: true,
+                name: true,
+                imageText: true,
+                createdAt: true,
+                updatedAt: true,
+                status: true,
+                userId: true,
+                memoImages: {
+                    take: 1, 
+                    orderBy: {
+                        createdAt: 'asc', 
+                    },
+                },
+            },
+            where: { // 폴더 이름이나 메모 텍스트에 검색어가 포함된 데이터 필터링
+                AND: [
+                    {
+                        userId: userId
+                    },
+                    {
+                        OR: [
+                            {
+                                name: { // name 필드에 searchKeyword가 포함된 데이터를 찾는다.
+                                    contains: searchKeyword,
+                                }
+                            },
+                            {
+                                imageText: { // imageText 필드에 searchKeyword가 포함된 데이터를 찾는다.
+                                    contains: searchKeyword,
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+
+        const formattedMemoSearchList = await Promise.all(
+            memoSearchList.map(async (memoSearch) => ({
+                ...memoSearch,
+                id: memoSearch.id.toString(),
+                memoImages: await Promise.all(
+                    memoSearch.memoImages.map(async (memoImage) => {
+                        const presignedUrl = await getPresignedUrl(memoImage.url);
+                        return {
+                            ...memoImage,
+                            id: memoImage.id.toString(),
+                            folderId: memoImage.folderId.toString(),
+                            url: presignedUrl // Pre-signed URL로 변환
+                        };
+                    })
+                ),
+            }))
+        );
+
+        return formattedMemoSearchList;
+    }
+    catch (err) {
+        throw new Error('서버 내부 오류 또는 존재하지 않는 데이터');
+    }
+};
+
+export const getMemoTextImageList = async (userId: bigint, folderId: bigint) => {
+    try {
+        const memoTextImageList = await prisma.memoFolder.findFirst({
+            select: {
+                id: true,
+                userId: true,
+                name: true,
+                imageText: true,
+                createdAt: true,
+                updatedAt: true,
+                status: true,
+                memoImages: {
+                    orderBy: {
+                        createdAt: 'asc', // 업로드된 시간순으로 정렬
+                    },
+                },
+            },
+            where: {
+                userId: userId,
+                id: folderId
+            }
+        });
+
+        if (memoTextImageList == null) {
+            return null;
+        }
+
+        const formattedMemoTextImageList = {
+            ...memoTextImageList,
+            id: memoTextImageList.id.toString(),
+            memoImages: await Promise.all(memoTextImageList.memoImages.map(async(memoImage) => {
+                const presignedUrl = await getPresignedUrl(memoImage.url);
+                return {
+                    ...memoImage,
+                    id: memoImage.id.toString(),
+                    folderId: memoImage.folderId.toString(),
+                    url: presignedUrl,
+                };
+            }))
+        };
+
+        return formattedMemoTextImageList;
     }
     catch (err) {
         throw new Error('서버 내부 오류 또는 존재하지 않는 데이터');

--- a/src/repositories/memo-folder.repository.ts
+++ b/src/repositories/memo-folder.repository.ts
@@ -63,6 +63,11 @@ export const getMemoFolderList = async (userId: bigint) => {
                 createdAt: true,
                 updatedAt: true,
                 status: true,
+                _count: { // 이미지 개수를 세는 필드 추가
+                    select: {
+                        memoImages: true, // memoImages의 개수를 가져온다.
+                    },
+                },
                 memoImages: {
                     take: 1, // 각 폴더에서 첫 번째 사진만 가져오기
                     orderBy: {
@@ -79,6 +84,7 @@ export const getMemoFolderList = async (userId: bigint) => {
             memoFolderList.map(async (memoFolder) => ({
                 ...memoFolder,
                 id: memoFolder.id.toString(),
+                imageCount: memoFolder._count?.memoImages || 0, // 이미지 개수 추가
                 memoImages: await Promise.all(
                     memoFolder.memoImages.map(async (memoImage) => {
                         const presignedUrl = await getPresignedUrl(memoImage.url);
@@ -111,6 +117,11 @@ export const getSearchMemoList = async (userId: bigint, searchKeyword: string) =
                 updatedAt: true,
                 status: true,
                 userId: true,
+                _count: { // 이미지 개수를 세는 필드 추가
+                    select: {
+                        memoImages: true, // memoImages의 개수를 가져온다.
+                    },
+                },
                 memoImages: {
                     take: 1, 
                     orderBy: {
@@ -146,6 +157,7 @@ export const getSearchMemoList = async (userId: bigint, searchKeyword: string) =
             memoSearchList.map(async (memoSearch) => ({
                 ...memoSearch,
                 id: memoSearch.id.toString(),
+                imageCount: memoSearch._count?.memoImages || 0, // 이미지 개수 추가
                 memoImages: await Promise.all(
                     memoSearch.memoImages.map(async (memoImage) => {
                         const presignedUrl = await getPresignedUrl(memoImage.url);

--- a/src/repositories/memo-folder.repository.ts
+++ b/src/repositories/memo-folder.repository.ts
@@ -1,8 +1,8 @@
 import { prisma } from '../db.config.js';
-import { BodyToMemoFolder } from '../models/memo-folder.model.js';
+import { BodyToMemoFolder, createdMemoFolderId, MemoFolderList, MemoFoler, MemoTextImageList } from '../models/memo-folder.model.js';
 import { getPresignedUrl } from '../s3/get-presigned-url.js';
 
-export const createMemoFolder = async (data: BodyToMemoFolder, userId: bigint) => {
+export const createMemoFolder = async (data: BodyToMemoFolder, userId: bigint) : Promise<bigint> => {
     try {
         const createdMemoFolder = await prisma.memoFolder.create({
             data: {
@@ -19,7 +19,7 @@ export const createMemoFolder = async (data: BodyToMemoFolder, userId: bigint) =
     }
 };
 
-export const getMemoFolder = async (memoFolderId: bigint) => {
+export const getMemoFolder = async (memoFolderId: bigint) : Promise<MemoFoler | null>=> {
     try {
         const memoFolder = await prisma.memoFolder.findFirst({
             where: {
@@ -52,7 +52,7 @@ export const getMemoFolder = async (memoFolderId: bigint) => {
     }
 };
 
-export const getMemoFolderList = async (userId: bigint) => {
+export const getMemoFolderList = async (userId: bigint): Promise<MemoFolderList[]> => {
     try {
         const memoFolderList = await prisma.memoFolder.findMany({
             select: {
@@ -106,7 +106,7 @@ export const getMemoFolderList = async (userId: bigint) => {
     }
 };
 
-export const getSearchMemoList = async (userId: bigint, searchKeyword: string) => {
+export const getSearchMemoList = async (userId: bigint, searchKeyword: string): Promise<MemoFolderList[]> => {
     try {
         const memoSearchList = await prisma.memoFolder.findMany({
             select: {
@@ -179,7 +179,7 @@ export const getSearchMemoList = async (userId: bigint, searchKeyword: string) =
     }
 };
 
-export const getMemoTextImageList = async (userId: bigint, folderId: bigint) => {
+export const getMemoTextImageList = async (userId: bigint, folderId: bigint): Promise<MemoTextImageList | null> => {
     try {
         const memoTextImageList = await prisma.memoFolder.findFirst({
             select: {

--- a/src/repositories/memo-image.repository.ts
+++ b/src/repositories/memo-image.repository.ts
@@ -1,7 +1,8 @@
 import { prisma } from '../db.config.js';
+import { MemoImage } from '../models/memo-image.model.js';
 import { getPresignedUrl } from '../s3/get-presigned-url.js';
 
-export const addMemoImage = async (memoFolderId: bigint, imageUrl: string) => {
+export const addMemoImage = async (memoFolderId: bigint, imageUrl: string): Promise<bigint> => {
     try {
         const addedMemoImageId = await prisma.memoImage.create({
             data: {
@@ -17,7 +18,7 @@ export const addMemoImage = async (memoFolderId: bigint, imageUrl: string) => {
     }
 };
 
-export const getMemoImage = async (memoImageId: bigint) => {
+export const getMemoImage = async (memoImageId: bigint): Promise<MemoImage | null> => {
     try {
         const memoImage = await prisma.memoImage.findFirst({
             where: {

--- a/src/routers/memo.router.ts
+++ b/src/routers/memo.router.ts
@@ -1,9 +1,12 @@
 import express from 'express';
 export const memoFolderRouter = express.Router();
-import { handlerMemoFolderAdd, handlerMemoFolderImageCreate } from '../controllers/memo-folder.controller.js';
+import { handlerMemoFolderAdd, handlerMemoFolderImageCreate, handlerMemoFolderList, handlerMemoSearch, handlerMemoTextImageList } from '../controllers/memo-folder.controller.js';
 import { imageUploader } from '../s3/image.uploader.js';
 import { handlerMemoImageAdd } from '../controllers/memo-image.controller.js';
 
 memoFolderRouter.post('/folders', handlerMemoFolderAdd);
 memoFolderRouter.post('/image-format/folders', imageUploader.single('image'), handlerMemoFolderImageCreate);
 memoFolderRouter.post('/image-format/folders/:folderId', imageUploader.single('image'), handlerMemoImageAdd);
+memoFolderRouter.get('/list', handlerMemoFolderList);
+memoFolderRouter.get('/search', handlerMemoSearch);
+memoFolderRouter.get('/folders/:folderId', handlerMemoTextImageList);

--- a/src/s3/get-presigned-url.ts
+++ b/src/s3/get-presigned-url.ts
@@ -2,7 +2,7 @@ import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { s3 } from './awsS3Client.js';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-export const getPresignedUrl = async (key: string) => {
+export const getPresignedUrl = async (key: string): Promise<string> => {
     const bucketName = process.env.AWS_S3_BUCKET_NAME;
     
     // AWS 리소스에 접근할 수 있는 Pre-signed URL 생성

--- a/src/s3/image.deleter.ts
+++ b/src/s3/image.deleter.ts
@@ -2,7 +2,7 @@ import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { s3 } from './awsS3Client.js';
 
 // AWS S3에서 특정 이미지를 삭제하는 함수
-export const imageDeleter = async (key: string) => {
+export const imageDeleter = async (key: string): Promise<void> =>{
     const bucketName = process.env.AWS_S3_BUCKET_NAME; // S3 버킷 이름
 
     // 삭제할 파일 정보 설정

--- a/src/s3/image.mover.ts
+++ b/src/s3/image.mover.ts
@@ -2,7 +2,7 @@ import { CopyObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { s3 } from './awsS3Client.js';
 
 // AWS S3에서 특정 이미지의 디렉토리를 변경하는 함수
-export const imageMover = async (userId: bigint, key: string, directory: bigint) => {
+export const imageMover = async (userId: bigint, key: string, directory: bigint): Promise<void> =>{
     // 원본 경로
     const bucketName = process.env.AWS_S3_BUCKET_NAME; // S3 버킷 이름
     const copySource = `${bucketName}/${key}`; // S3 복사 작업에서의 원본 객체(버킷이름/객체키)

--- a/src/services/memo-folder.service.ts
+++ b/src/services/memo-folder.service.ts
@@ -1,6 +1,6 @@
-import { responseFromMemoFolder, responseFromMemoFolderImage } from '../dtos/memo-folder.dto.js';
+import { responseFromMemoFolder, responseFromMemoFolderImage, responseFromMemoFolderList, responseFromMemoTextImageList } from '../dtos/memo-folder.dto.js';
 import { BodyToMemoFolder } from '../models/memo-folder.model.js';
-import { createMemoFolder, getMemoFolder } from '../repositories/memo-folder.repository.js';
+import { createMemoFolder, getMemoFolder, getMemoFolderList, getMemoTextImageList, getSearchMemoList } from '../repositories/memo-folder.repository.js';
 import { addMemoImage, getMemoImage } from '../repositories/memo-image.repository.js';
 
 export const memoFolderCreate = async (userId: bigint, body: BodyToMemoFolder) => {
@@ -25,4 +25,22 @@ export const memoFolderImageCreate = async (folderId: bigint, imageUrl: string) 
         throw new Error('메모 사진 추가 에러');
     }
     return responseFromMemoFolderImage({ memoFolder, memoImage });
+};
+
+export const listMemoFolder = async (userId: bigint) => {
+    const memoFolderList = await getMemoFolderList(userId);
+    return responseFromMemoFolderList(memoFolderList);
+};
+
+export const memoSearch = async (userId: bigint, searchKeyword: string) => {
+    const searchMemoList = await getSearchMemoList(userId, searchKeyword);
+    return responseFromMemoFolderList(searchMemoList);
+};
+
+export const listMemoTextImage = async (userId: bigint, folderId: bigint) => {
+    const memoTextImageList = await getMemoTextImageList(userId, folderId);
+    if (memoTextImageList === null) {
+        throw new Error('해당 폴더가 존재하지 않습니다.');
+    }
+    return responseFromMemoTextImageList(memoTextImageList);
 };

--- a/src/services/memo-folder.service.ts
+++ b/src/services/memo-folder.service.ts
@@ -1,9 +1,9 @@
 import { responseFromMemoFolder, responseFromMemoFolderImage, responseFromMemoFolderList, responseFromMemoTextImageList } from '../dtos/memo-folder.dto.js';
-import { BodyToMemoFolder } from '../models/memo-folder.model.js';
+import { BodyToMemoFolder, MemoFolderImageResponseDto, MemoFolderListResponseDto, MemoFolderResponseDto, MemoTextImageListResponseDto } from '../models/memo-folder.model.js';
 import { createMemoFolder, getMemoFolder, getMemoFolderList, getMemoTextImageList, getSearchMemoList } from '../repositories/memo-folder.repository.js';
 import { addMemoImage, getMemoImage } from '../repositories/memo-image.repository.js';
 
-export const memoFolderCreate = async (userId: bigint, body: BodyToMemoFolder) => {
+export const memoFolderCreate = async (userId: bigint, body: BodyToMemoFolder):Promise<MemoFolderResponseDto> => {
     const createdMemoFolderId = await createMemoFolder(body, userId);
     const memoFolder = await getMemoFolder(createdMemoFolderId);
     console.log(memoFolder);
@@ -13,7 +13,7 @@ export const memoFolderCreate = async (userId: bigint, body: BodyToMemoFolder) =
     return responseFromMemoFolder(memoFolder);
 };
 
-export const memoFolderImageCreate = async (folderId: bigint, imageUrl: string) => {
+export const memoFolderImageCreate = async (folderId: bigint, imageUrl: string):Promise<MemoFolderImageResponseDto> => {
     //const createdMemoFolderId = await createMemoFolder(body, userId);
     const addedMemoImageId = await addMemoImage(folderId, imageUrl);
     const memoFolder = await getMemoFolder(folderId);
@@ -27,17 +27,17 @@ export const memoFolderImageCreate = async (folderId: bigint, imageUrl: string) 
     return responseFromMemoFolderImage({ memoFolder, memoImage });
 };
 
-export const listMemoFolder = async (userId: bigint) => {
+export const listMemoFolder = async (userId: bigint): Promise<{ data: MemoFolderListResponseDto[] }> => {
     const memoFolderList = await getMemoFolderList(userId);
     return responseFromMemoFolderList(memoFolderList);
 };
 
-export const memoSearch = async (userId: bigint, searchKeyword: string) => {
+export const memoSearch = async (userId: bigint, searchKeyword: string): Promise<{ data: MemoFolderListResponseDto[] }> => {
     const searchMemoList = await getSearchMemoList(userId, searchKeyword);
     return responseFromMemoFolderList(searchMemoList);
 };
 
-export const listMemoTextImage = async (userId: bigint, folderId: bigint) => {
+export const listMemoTextImage = async (userId: bigint, folderId: bigint): Promise<MemoTextImageListResponseDto> => {
     const memoTextImageList = await getMemoTextImageList(userId, folderId);
     if (memoTextImageList === null) {
         throw new Error('해당 폴더가 존재하지 않습니다.');

--- a/src/services/memo-image.service.ts
+++ b/src/services/memo-image.service.ts
@@ -1,9 +1,10 @@
 import { responseFromMemoFolderImage } from '../dtos/memo-folder.dto.js';
+import { MemoFolderImageResponseDto } from '../models/memo-folder.model.js';
 import { getMemoFolder } from '../repositories/memo-folder.repository.js';
 import { addMemoImage, getMemoImage } from '../repositories/memo-image.repository.js';
 
 
-export const memoImageAdd = async (folderId: bigint, imageUrl: string) => {
+export const memoImageAdd = async (folderId: bigint, imageUrl: string): Promise<MemoFolderImageResponseDto> => {
     const addedMemoImageId = await addMemoImage(folderId, imageUrl);
     const memoFolder = await getMemoFolder(folderId);
     const memoImage = await getMemoImage(addedMemoImageId);


### PR DESCRIPTION
# Sweepic Server PR List
close #51 

## ⚒️develop의 최신 커밋을 pull 받았나요?
- [X] 최신 커밋 업데이트

## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 메모장 조회 API 구현 (GET)
  - 사용자의 메모 폴더 리스트 조회 API -> 사용자 ID로 메모 폴더 리스트를 모두 가져온다.
  - 메모 검색 API -> 특정 키워드를 포함한 폴더 제목 또는 내용의 메모를 모두 가져온다.
  - 특정 폴더의 메모 리스트 조회 API -> 폴더 ID로 해당 메모들을 모두 가져온다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요? (핵심 작업 내용)
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 단순히 ID로 데이터를 조회하는 API 구현이어서 어떤 식으로 데이터를 반환하는 지를 repository의 핵심 코드 중심으로 설명 드리겠습니다.
- 사용자의 메모 폴더 리스트 조회 API
  ![image](https://github.com/user-attachments/assets/744a7a43-f6c4-4f33-8f5f-76c773c12bbd)
  - 피그마를 보시면 전체 메모를 조회하는 페이지에서 각 폴더에 폴더 이름, 생성일, 메모 텍스트의 일부, 사진 1장(해당 폴더의 첫 번째 이미지라고 생각했습니다), 사진 장수를 띄웁니다. 
  ```  
  export const getMemoFolderList = async (userId: bigint) => {
      try {
          const memoFolderList = await prisma.memoFolder.findMany({
              select: {
                  id: true,
                  ... (생략) ...
                  _count: { // 이미지 개수를 세는 필드 추가
                      select: {
                          memoImages: true, // memoImages의 개수를 가져온다.
                      },
                  },
                  memoImages: {
                      take: 1, // 각 폴더에서 첫 번째 사진만 가져오기
                      orderBy: {
                          createdAt: 'asc', // 업로드된 시간순으로 정렬
                      },
                  },
              },
              where: {
                  userId: userId
              }
          });

          const formattedMemoFolderList = await Promise.all( // 비동기 작업이 완료될 때까지 기다린 후 처리된 결과를 배열로 반환
              memoFolderList.map(async (memoFolder) => ({
                  ...memoFolder,
                  id: memoFolder.id.toString(),
                  imageCount: memoFolder._count?.memoImages || 0, // 이미지 개수 추가
                  memoImages: await Promise.all(
                      memoFolder.memoImages.map(async (memoImage) => {
                          const presignedUrl = await getPresignedUrl(memoImage.url);
                          return {
                              ...memoImage,
                              id: memoImage.id.toString(),
                              folderId: memoImage.folderId.toString(),
                              url: presignedUrl // Pre-signed URL로 변환
                          };
                      })
                  ),
              }))
          );

          return formattedMemoFolderList;
      }
      ...
  };
  ```
  - memoFolder.findMany에서 _count로 이미지의 개수를 세고, memoImages의 사진 생성일 기준 첫 번째 사진만 가져오도록 했습니다. 마지막으론 이미지 key를 pre-signed url로 반환하는 과정에서 Promise.all을 사용해 memoFolders와 memoImages의 병렬 처리(모든 비동기 작업이 완료될 때까지 대기 후 그 결과를 배열로 반환)를 최적화해주었습니다. 
  ```
  // src/dtos/memo-folder.dto.ts

  export const responseFromMemoFolderList = (searchMemoList: ResponseFromMemoList[]) => {
      return {
          data: searchMemoList.map(({ id: folderId, name: folderName, imageCount, imageText, memoImages }) => {
              const [firstImage] = memoImages; // memoImages의 첫 번째 항목 구조 분해
              return {
                  folderId,
                  folderName,
                  imageText,
                  imageCount,
                  firstImageId: firstImage?.id || null, 
                  firstImageUrl: firstImage?.url || null, 
              };
          }),
      };
  };
  ```
  - 응답 DTO에 imageCount(사진 장수) 및 첫 번째 이미지 등을 포함해 프론트에게 반환하도록 구현했습니다.
- 메모 검색 API
  ```
  export const getSearchMemoList = async (userId: bigint, searchKeyword: string) => {
      try {
          const memoSearchList = await prisma.memoFolder.findMany({
              select: {
                  ...
              },
              where: { // 폴더 이름이나 메모 텍스트에 검색어가 포함된 데이터 필터링
                  AND: [
                      {
                          userId: userId
                      },
                      {
                          OR: [
                              {
                                  name: { // name 필드에 searchKeyword가 포함된 데이터를 찾는다.
                                      contains: searchKeyword,
                                  }
                              },
                              {
                                  imageText: { // imageText 필드에 searchKeyword가 포함된 데이터를 찾는다.
                                      contains: searchKeyword,
                                  }
                              }
                          ]
                      }
                  ]
              }
          });
          ...
          return formattedMemoSearchList;
      }
      ...
  };
  ```
  - 메모를 검색해서 조회할 경우, 사용자가 입력한 검색어를 포함하는 폴더 이름 및 메모 텍스트를 가지는 폴더들을 모두 조회하였습니다. 응답 형식은 전체 메모를 조회하는 API와 동일합니다.
- 특정 폴더의 메모 리스트 조회
  - 사용자 ID와 폴더 ID를 통해 사용자의 특정 폴더의 내용물(텍스트 및 사진)들을 가져왔습니다. 이는 단순 조회 API라서 따로 코드를 넣지 않았는데 커밋을 통해 살펴봐주시면 감사하겠습니다. 

## 🤚 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스크린 샷을 올려주세요
- yarn lint, compile, fix, pretest
  ![image](https://github.com/user-attachments/assets/e20a0a64-471b-43c2-8efa-b6790a55ebb0)
-  사용자의 메모 폴더 리스트 조회 API
  ![image](https://github.com/user-attachments/assets/a8267e45-4166-4318-ad59-13f2afe6e3c7)
  ![image](https://github.com/user-attachments/assets/dac697fc-fba0-4b3a-a05a-f8b394da8357)
- 메모 검색 API
  ![image](https://github.com/user-attachments/assets/ee624ed4-3f19-49d5-ada4-b0a4ba8120a6)
  ![image](https://github.com/user-attachments/assets/51235f76-2cb9-4e8b-a13c-0d3afc87707c)
- 특정 폴더의 메모 리스트 조회 API 
  ![image](https://github.com/user-attachments/assets/47f2a523-ed00-46c1-b2d0-baccb296c57d)
  ![image](https://github.com/user-attachments/assets/56f088e1-53f2-4133-8f43-d724b1bbf738)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
- 없음

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
- API 전체적으로 살펴봐주시면 감사하겠습니다. 더 효율적인 코드나 필요한 부분이 있다면 알려주세요.

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **2일 이내**에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [X] To-Do Item
