### PR TITLE
refactor: 메모장 텍스트 수정 API 에러 처리 추가 및 swagger 실패 응답 예시 작성

### DIFF
--- a/src/controllers/memo-folder.controller.ts
+++ b/src/controllers/memo-folder.controller.ts
@@ -4,7 +4,7 @@ import { bodyToMemoFolder, bodyToMemoTextToUpdate } from '../dtos/memo-folder.dt
 import { listMemoFolder, listMemoTextImage, memoFolderCreate, memoFolderImageCreate, memoFolderUpdate, memoSearch, memoTextUpdate } from '../services/memo-folder.service.js';
 import { memoFolderDelete, memoImageDelete } from '../services/memo-image.service.js';
 import { bodyToMemoImagesToDelete } from '../dtos/memo-image.dto.js';
-import { DataValidationError } from '../errors.js';
+import { DataValidationError, PhotoValidationError } from '../errors.js';
 
 export const handlerMemoFolderImageCreate = async (
   req: Request,
@@ -57,6 +57,119 @@ export const handlerMemoFolderImageCreate = async (
             }
         }
     };
+    #swagger.responses[400] = {
+        description: "유효하지 않은 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "400" },
+                                reason: { type: "string" },
+                                data: {},
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+                examples: {
+                    "폴더 생성 에러": {
+                        summary: "폴더 생성 에러",
+                        description: "폴더 생성 중 오류가 발생했습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "FOL-400",
+                                reason: "폴더 생성 중 오류가 발생했습니다.",
+                                data: {
+                                    userId: "1",
+                                    folderName: "string"
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "유효하지 않은 사진 데이터 에러": {
+                        summary: "유효하지 않은 사진 데이터 에러",
+                        description: "저장할 사진이 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "PHO-400",
+                                reason: "사진 데이터가 유효하지 않습니다.",
+                                data: {
+                                    reason: "저장할 사진이 없습니다."
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "사진 추가 에러": {
+                        summary: "사진 추가 에러",
+                        description: "메모 사진 추가 중 오류가 발생했습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "MEM-400",
+                                reason: "메모 사진 추가 중 오류가 발생했습니다.",
+                                data: {
+                                    folderId: "1",
+                                    imageUrl: "string"
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "유효하지 않은 확장자 에러": {
+                        summary: "유효하지 않은 확장자 에러",
+                        description: "이미지 확장자가 유효하지 않습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "PHO-400",
+                                reason: "사진 데이터가 유효하지 않습니다.",
+                                data: {
+                                    extension: "string"
+                                }
+                            },
+                            success: null 
+                        }
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[409] = {
+        description: "폴더명 중복 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-409" },
+                                reason: { type: "string", example: "이미 존재하는 폴더 이름입니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderName: { type: "string" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                }
+            }
+        }
+    };
     */
     try{
         console.log('폴더 생성 및 사진 추가');
@@ -64,7 +177,7 @@ export const handlerMemoFolderImageCreate = async (
         console.log('image: ', req.file);
         const userId = BigInt(req.user!.id);
         if (!req.file) {
-            throw new DataValidationError({reason: '저장할 사진이 없습니다.'});
+            throw new PhotoValidationError({reason: '저장할 사진이 없습니다.'});
         }
         const imageUrl = (req.file as Express.MulterS3File).key;
         const folderId = req.uploadDirectory;
@@ -116,6 +229,61 @@ export const handlerMemoFolderAdd = async (
                                 folderName: { type: "string" },
                             }
                         }   
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[400] = {
+        description: "사진 추가 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-400" },
+                                reason: { type: "string", example: "폴더 생성 중 오류가 발생했습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        userId: { type: "string", example: "1" },
+                                        folderName: { type: "string" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+            }
+        }
+    };
+    #swagger.responses[409] = {
+        description: "폴더명 중복 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-409" },
+                                reason: { type: "string", example: "이미 존재하는 폴더 이름입니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderName: { type: "string" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
                     }
                 }
             }
@@ -243,6 +411,33 @@ export const handlerMemoSearch = async (
             }
         }
     };
+    #swagger.responses[400] = {
+        description: "유효하지 않은 입력 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "SRH-400" },
+                                reason: { type: "string", example: "입력 데이터가 유효하지 않습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        reason: { type: "string", example: "검색어를 1자 이상 입력하세요." },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                }
+            }
+        }
+    };
     */
     try{
         console.log('메모 검색');
@@ -320,6 +515,60 @@ export const handlerMemoImageDelete = async (req: Request, res: Response, next: 
             }
         }
     };
+    #swagger.responses[404] = {
+        description: "조회할 수 없는 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "404" },
+                                reason: { type: "string" },
+                                data: {},
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+                examples: {
+                    "폴더 조회 에러": {
+                        summary: "폴더 조회 에러",
+                        description: "해당 폴더를 찾을 수 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "FOL-404",
+                                reason: "해당 폴더를 찾을 수 없습니다.",
+                                data: {
+                                    folderId: "1",
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "사진 조회 에러": {
+                        summary: "사진 조회 에러",
+                        description: "해당 사진 데이터가 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "PHO-404",
+                                reason: "해당 사진 데이터가 없습니다.",
+                                data: {
+                                    imageId: "1"
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                }
+            }
+        }
+    };
     */
     try{
         const userId = BigInt(req.user!.id);
@@ -377,6 +626,33 @@ export const handlerMemoTextImageList = async (
                                 }
                             }
                         }     
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[404] = {
+        description: "폴더 조회 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-404" },
+                                reason: { type: "string", example: "해당 폴더를 찾을 수 없습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderId: { type: "string", example: "1" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
                     }
                 }
             }
@@ -456,6 +732,114 @@ export const handlerMemoFolderUpdate = async (req: Request, res: Response, next:
             }
         }
     };
+    #swagger.responses[404] = {
+        description: "폴더 조회 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-404" },
+                                reason: { type: "string", example: "해당 폴더를 찾을 수 없습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderId: { type: "string", example: "1" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[409] = {
+        description: "폴더명 중복 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-409" },
+                                reason: { type: "string", example: "이미 존재하는 폴더 이름입니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderName: { type: "string" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[400] = {
+        description: "유효하지 않은 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "400" },
+                                reason: { type: "string" },
+                                data: {},
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+                examples: {
+                    "폴더명 업데이트 에러": {
+                        summary: "폴더명 업데이트 에러",
+                        description: "폴더 업데이트 중 오류가 발생했습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "FOL-400",
+                                reason: "폴더 업데이트 중 오류가 발생했습니다.",
+                                data: {
+                                    folderId: "1",
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "변경 전과 동일한 폴더명 에러": {
+                        summary: "변경 전과 동일한 폴더명 에러",
+                        description: "변경 전의 폴더 이름과 같습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "FOL-400",
+                                reason: "변경 전의 폴더 이름과 같습니다.",
+                                data: {
+                                    folderName: "string"
+                                }
+                            },
+                            success: null 
+                        }
+                    }
+                }
+            }
+        }
+    };
     */
     try{
         const userId = BigInt(req.user!.id);
@@ -524,6 +908,33 @@ export const handlerMemoTextUpdate = async (req: Request, res: Response, next: N
                                 }
                             }
                         }     
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[404] = {
+        description: "폴더 조회 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-404" },
+                                reason: { type: "string", example: "해당 폴더를 찾을 수 없습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderId: { type: "string", example: "1" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
                     }
                 }
             }

--- a/src/controllers/memo-image.controller.ts
+++ b/src/controllers/memo-image.controller.ts
@@ -2,7 +2,7 @@ import { Response, Request, NextFunction } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { memoFolderDelete, memoImageAdd, memoImageDelete, memoImagesMove } from '../services/memo-image.service.js';
 import { bodyToMemoImagesToDelete, bodyToMemoImagesToMove } from '../dtos/memo-image.dto.js';
-import { DataValidationError } from '../errors.js';
+import { DataValidationError, PhotoDataNotFoundError } from '../errors.js';
 
 export const handlerMemoImageAdd = async (
   req: Request,
@@ -62,13 +62,122 @@ export const handlerMemoImageAdd = async (
             }
         }
     };
+    #swagger.responses[404] = {
+        description: "조회할 수 없는 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "404" },
+                                reason: { type: "string" },
+                                data: {},
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+                examples: {
+                    "폴더 조회 에러": {
+                        summary: "폴더 조회 에러",
+                        description: "해당 폴더를 찾을 수 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "FOL-404",
+                                reason: "해당 폴더를 찾을 수 없습니다.",
+                                data: {
+                                    folderId: "1",
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "사진 조회 에러": {
+                        summary: "사진 조회 에러",
+                        description: "해당 사진 데이터가 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "PHO-404",
+                                reason: "해당 사진 데이터가 없습니다.",
+                                data: {
+                                    reason: "저장할 사진이 없습니다."
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                }
+            }
+        }
+    };
+    #swagger.responses[400] = {
+        description: "유효하지 않은 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "400" },
+                                reason: { type: "string" },
+                                data: {},
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+                examples: {
+                    "사진 추가 에러": {
+                        summary: "사진 추가 에러",
+                        description: "메모 사진 추가 중 오류가 발생했습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "MEM-400",
+                                reason: "메모 사진 추가 중 오류가 발생했습니다.",
+                                data: {
+                                    folderId: "1",
+                                    imageUrl: "string"
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "유효하지 않은 확장자 에러": {
+                        summary: "유효하지 않은 확장자 에러",
+                        description: "이미지 확장자가 유효하지 않습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "PHO-400",
+                                reason: "사진 데이터가 유효하지 않습니다.",
+                                data: {
+                                    extension: "string"
+                                }
+                            },
+                            success: null 
+                        }
+                    }
+                }
+            }
+        }
+    };
     */
     try{
         console.log('특정 폴더에 사진 추가');
         console.log('body: ', req.body);
         const folderId = BigInt(req.params.folderId);
         if (!req.file) {
-            throw new DataValidationError({reason: '저장할 사진이 없습니다.'});
+            throw new PhotoDataNotFoundError({reason: '저장할 사진이 없습니다.'});
         }
         const imageUrl = (req.file as Express.MulterS3File).key;
         const memoImage = await memoImageAdd(folderId, imageUrl);
@@ -132,6 +241,94 @@ export const handlerMemoImageMove = async (req: Request, res: Response, next: Ne
             }
         }
     };
+    #swagger.responses[404] = {
+        description: "조회할 수 없는 데이터 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "404" },
+                                reason: { type: "string" },
+                                data: {},
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                },
+                examples: {
+                    "폴더 조회 에러": {
+                        summary: "폴더 조회 에러",
+                        description: "해당 폴더를 찾을 수 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "FOL-404",
+                                reason: "해당 폴더를 찾을 수 없습니다.",
+                                data: {
+                                    folderId: "1",
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                    "사진 조회 에러": {
+                        summary: "사진 조회 에러",
+                        description: "해당 사진 데이터가 없습니다.",
+                        value: {
+                            resultType: "FAIL",
+                            error: { 
+                                errorCode: "PHO-404",
+                                reason: "해당 사진 데이터가 없습니다.",
+                                data: {
+                                    imageId: "1"
+                                }
+                            },
+                            success: null 
+                        }
+                    },
+                }
+            }
+        }
+    };
+    #swagger.responses[400] = {
+        description: "사진 이동 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "MEM-400" },
+                                reason: { type: "string", example: "메모 사진 이동 중 오류가 발생했습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderId: { type: "string", example: "1" },
+                                        imageId: {
+                                            type: "array",
+                                            items: {
+                                                type: "string",
+                                                example: "1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
+                    }
+                }
+            }
+        }
+    };
     */
     try{
         const userId = BigInt(req.user!.id);
@@ -174,6 +371,33 @@ export const handlerMemoFolderDelete = async (req: Request, res: Response, next:
                                 message: { type: "string" }
                             }
                         }      
+                    }
+                }
+            }
+        }
+    };
+    #swagger.responses[404] = {
+        description: "폴더 조회 에러",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: { 
+                            type: "object", 
+                            properties: {
+                                errorCode: { type: "string", example: "FOL-404" },
+                                reason: { type: "string", example: "해당 폴더를 찾을 수 없습니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        folderId: { type: "string", example: "1" },
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null },  
                     }
                 }
             }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,6 +5,7 @@ export type ErrorDetails =
   | {latitude?: number; longitude?: number}
   | {reason?: string}
   | {searchKeyword?: string}
+  | {extension?: string}
   | null;
 
 // 기본 에러 클래스
@@ -60,7 +61,7 @@ export class FolderNotChangeError extends BaseError {
 
 export class FolderNameNotChangeError extends BaseError {
   constructor(details: {folderName: string}) {
-    super(409, 'FOL-409', '변경 전의 폴더 이름과 같습니다.', details);
+    super(400, 'FOL-400', '변경 전의 폴더 이름과 같습니다.', details);
   }
 }
 
@@ -189,7 +190,13 @@ export class DateChallengeNotFoundError extends BaseError {
 // 사진 데이터 관련 에러 (PHO-photo)
 export class PhotoDataNotFoundError extends BaseError {
   constructor(details?: ErrorDetails) {
-    super(404, 'PHO-404', '사진 데이터가 없습니다.', details);
+    super(404, 'PHO-404', '해당 사진 데이터가 없습니다.', details);
+  }
+}
+
+export class PhotoValidationError extends BaseError {
+  constructor(details?: ErrorDetails) {
+    super(400, 'PHO-400', '사진 데이터가 유효하지 않습니다.', details);
   }
 }
 

--- a/src/s3/image.uploader.ts
+++ b/src/s3/image.uploader.ts
@@ -6,7 +6,7 @@ import path from 'path'; // 확장자 처리
 import { s3 } from './awsS3Client.js';
 import { createMemoFolder } from '../repositories/memo-folder.repository.js';
 import { bodyToMemoFolder } from '../dtos/memo-folder.dto.js';
-import { DataValidationError, FolderDuplicateError } from '../errors.js';
+import { DataValidationError, FolderDuplicateError, PhotoValidationError } from '../errors.js';
 
 const allowedExtensions = ['.png', '.jpg', '.jpeg', '.bmp', '.PNG', '.JPG', '.webp']; // 확장자 검사 목록
 export const imageUploader = multer({ // 파일 업로드 미들웨어 설정
@@ -20,7 +20,7 @@ export const imageUploader = multer({ // 파일 업로드 미들웨어 설정
             const uuid = uuidv4(); // UUID 생성
             const extension = path.extname(file.originalname); // 파일 이름(확장자) 추출
             if (!allowedExtensions.includes(extension)) { // 업로드 파일의 확장자가 허용 목록에 없을 경우
-                return callback(new DataValidationError({reason: '이미지 확장자가 유효하지 않습니다.'}));
+                return callback(new PhotoValidationError({extension: extension}));
             }
             
             // 디렉토리 path 설정 과정

--- a/src/services/memo-folder.service.ts
+++ b/src/services/memo-folder.service.ts
@@ -74,6 +74,10 @@ export const memoFolderUpdate = async (userId: bigint, folderId: bigint, body: B
 };
 
 export const memoTextUpdate = async (userId: bigint, folderId: bigint, body: BodyToMemoTextToUpdate): Promise<MemoTextImageListResponseDto> => {
+    const folder = await getMemoFolder(folderId);
+    if (folder === null) {
+        throw new FolderNotFoundError({folderId});
+    }
     const updatedMemoText = await updateMemoText(userId, folderId, body);
     return responseFromMemoTextImageList(updatedMemoText);
 };

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -18,60 +18,1593 @@
     },
     "/oauth2/login/naver": {
       "get": {
-        "description": "",
+        "tags": [
+          "OAuth"
+        ],
+        "summary": "네이버 로그인 URL 요청",
+        "description": "네이버 OAuth 로그인을 시작하는 엔드포인트입니다. 브라우저에서 호출하면 네이버 로그인 페이지로 리디렉트됩니다.",
         "responses": {
-          "default": {
-            "description": ""
+          "302": {
+            "description": "네이버 로그인 페이지로 리디렉트",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "example": "https://3.37.137.212:3000/oauth2/login/naver"
+              }
+            }
           }
         }
       }
     },
     "/oauth2/callback/naver": {
       "get": {
-        "description": "",
+        "tags": [
+          "OAuth"
+        ],
+        "summary": "네이버 로그인 콜백",
+        "description": "네이버 OAuth 인증 후 리디렉션되는 엔드포인트입니다. 로그인 성공 시 세션을 생성하고 메인 페이지로 리디렉트합니다.",
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "로그인 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "jwt_token_here"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "user@example.com"
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "홍길동"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "jwt_token_here"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "user@example.com"
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "홍길동"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "Unauthorized"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "Unauthorized"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
           }
         }
       }
     },
     "/oauth2/login/google": {
       "get": {
-        "description": "",
+        "tags": [
+          "OAuth"
+        ],
+        "summary": "구글 로그인 URL 요청",
+        "description": "구글 OAuth 로그인을 시작하는 엔드포인트입니다.",
         "responses": {
-          "default": {
-            "description": ""
+          "302": {
+            "description": "구글 로그인 페이지로 리디렉트",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "example": "https://3.37.137.212:3000/oauth2/login/google"
+              }
+            }
           }
         }
       }
     },
     "/oauth2/callback/google": {
       "get": {
-        "description": "",
+        "tags": [
+          "OAuth"
+        ],
+        "summary": "구글 로그인 콜백",
+        "description": "구글 OAuth 인증 후 리디렉션되는 엔드포인트입니다. 로그인 성공 시 세션을 생성하고 메인 페이지로 리디렉트합니다.",
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "로그인 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "jwt_token_here"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "user@example.com"
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "홍길동"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "jwt_token_here"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "user@example.com"
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "홍길동"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "Unauthorized"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "Unauthorized"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
           }
         }
       }
     },
     "/oauth2/login/kakao": {
       "get": {
-        "description": "",
+        "tags": [
+          "OAuth"
+        ],
+        "summary": "카카오 로그인 URL 요청",
+        "description": "카카오 OAuth 로그인을 시작하는 엔드포인트입니다.",
         "responses": {
-          "default": {
-            "description": ""
+          "302": {
+            "description": "카카오 로그인 페이지로 리디렉트",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "example": "https://3.37.137.212:3000/oauth2/login/kakao"
+              }
+            }
           }
         }
       }
     },
     "/oauth2/callback/kakao": {
       "get": {
-        "description": "",
+        "tags": [
+          "OAuth"
+        ],
+        "summary": "카카오 로그인 콜백",
+        "description": "카카오 OAuth 인증 후 리디렉션되는 엔드포인트입니다. 로그인 성공 시 세션을 생성하고 메인 페이지로 리디렉트합니다.",
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "로그인 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "jwt_token_here"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "user@example.com"
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "홍길동"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "jwt_token_here"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "user@example.com"
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "홍길동"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "Unauthorized"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "Unauthorized"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/onboarding/name": {
+      "patch": {
+        "tags": [
+          "User"
+        ],
+        "summary": "사용자 이름 변경 API",
+        "description": "로그인한 사용자의 이름을 변경하는 API입니다.",
+        "responses": {
+          "200": {
+            "description": "사용자 이름 변경 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "SUCCESS"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "John Doe"
+                                    }
+                                  }
+                                },
+                                "updatedAt": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "format": {
+                                      "type": "string",
+                                      "example": "date-time"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "SUCCESS"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "John Doe"
+                                    }
+                                  }
+                                },
+                                "updatedAt": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "format": {
+                                      "type": "string",
+                                      "example": "date-time"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "잘못된 요청",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "FAILURE"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "reason": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "Name is required."
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "FAILURE"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "reason": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "Name is required."
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "변경할 사용자 이름"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/onboarding/goal": {
+      "patch": {
+        "tags": [
+          "User"
+        ],
+        "summary": "사용자 목표 장수 변경 API",
+        "description": "로그인한 사용자의 목표 장수를 변경하는 API입니다.",
+        "responses": {
+          "200": {
+            "description": "목표 장수 변경 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "SUCCESS"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "goalCount": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 5
+                                    }
+                                  }
+                                },
+                                "updatedAt": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "format": {
+                                      "type": "string",
+                                      "example": "date-time"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "SUCCESS"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 1
+                                    }
+                                  }
+                                },
+                                "goalCount": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "integer"
+                                    },
+                                    "example": {
+                                      "type": "number",
+                                      "example": 5
+                                    }
+                                  }
+                                },
+                                "updatedAt": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "format": {
+                                      "type": "string",
+                                      "example": "date-time"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "잘못된 요청",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "FAILURE"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "reason": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "goal_count is required."
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "example": "object"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "resultType": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "string"
+                            },
+                            "example": {
+                              "type": "string",
+                              "example": "FAILURE"
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "properties": {
+                              "type": "object",
+                              "properties": {
+                                "reason": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "example": "string"
+                                    },
+                                    "example": {
+                                      "type": "string",
+                                      "example": "goal_count is required."
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "success": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "object"
+                            },
+                            "nullable": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "example": {}
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "goalCount": {
+                    "type": "integer",
+                    "description": "변경할 목표 장수"
+                  }
+                },
+                "required": [
+                  "goalCount"
+                ]
+              }
+            }
           }
         }
       }
@@ -116,6 +1649,94 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "사진 추가 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-400"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "폴더 생성 중 오류가 발생했습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "userId": {
+                              "type": "string",
+                              "example": "1"
+                            },
+                            "folderName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "폴더명 중복 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-409"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "이미 존재하는 폴더 이름입니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "requestBody": {
@@ -131,6 +1752,458 @@
                   "folderName": {
                     "type": "string",
                     "description": "폴더 이름"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/memo/folders/{folderId}": {
+      "get": {
+        "tags": [
+          "memo-folder-controller"
+        ],
+        "summary": "특정 폴더의 메모 조회 API",
+        "description": "특정 폴더의 모든 메모(텍스트 및 사진)을 조회하는 API입니다.",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "폴더 ID 입력"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "메모 조회 성공 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "SUCCESS"
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "folderId": {
+                          "type": "string",
+                          "example": "1"
+                        },
+                        "folderName": {
+                          "type": "string"
+                        },
+                        "imageText": {
+                          "type": "string"
+                        },
+                        "images": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "imageId": {
+                                "type": "string",
+                                "example": "1"
+                              },
+                              "imageUrl": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "폴더 조회 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-404"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "해당 폴더를 찾을 수 없습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderId": {
+                              "type": "string",
+                              "example": "1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "memo-folder-controller"
+        ],
+        "summary": "메모 폴더 이름 수정 API",
+        "description": "특정 폴더의 이름을 수정하는 API입니다.",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "폴더 ID 입력"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "폴더 이름 수정 성공 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "SUCCESS"
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "folderId": {
+                          "type": "string",
+                          "example": "1"
+                        },
+                        "folderName": {
+                          "type": "string"
+                        },
+                        "imageText": {
+                          "type": "string"
+                        },
+                        "images": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "imageId": {
+                                "type": "string",
+                                "example": "1"
+                              },
+                              "imageUrl": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "400"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "폴더명 업데이트 에러": {
+                    "summary": "폴더명 업데이트 에러",
+                    "description": "폴더 업데이트 중 오류가 발생했습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "FOL-400",
+                        "reason": "폴더 업데이트 중 오류가 발생했습니다.",
+                        "data": {
+                          "folderId": "1"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "변경 전과 동일한 폴더명 에러": {
+                    "summary": "변경 전과 동일한 폴더명 에러",
+                    "description": "변경 전의 폴더 이름과 같습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "FOL-400",
+                        "reason": "변경 전의 폴더 이름과 같습니다.",
+                        "data": {
+                          "folderName": "string"
+                        }
+                      },
+                      "success": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "폴더 조회 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-404"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "해당 폴더를 찾을 수 없습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderId": {
+                              "type": "string",
+                              "example": "1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "폴더명 중복 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-409"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "이미 존재하는 폴더 이름입니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "folderName"
+                ],
+                "properties": {
+                  "folderName": {
+                    "type": "string",
+                    "description": "폴더 이름"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "memo-folder-controller"
+        ],
+        "summary": "폴더 삭제 API",
+        "description": "특정 폴더를 삭제하는 API입니다.",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "폴더 ID 입력"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "폴더 삭제 성공 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "SUCCESS"
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "폴더 조회 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-404"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "해당 폴더를 찾을 수 없습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderId": {
+                              "type": "string",
+                              "example": "1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
                   }
                 }
               }
@@ -181,6 +2254,146 @@
                           "type": "string"
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "400"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "폴더 생성 에러": {
+                    "summary": "폴더 생성 에러",
+                    "description": "폴더 생성 중 오류가 발생했습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "FOL-400",
+                        "reason": "폴더 생성 중 오류가 발생했습니다.",
+                        "data": {
+                          "userId": "1",
+                          "folderName": "string"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "유효하지 않은 사진 데이터 에러": {
+                    "summary": "유효하지 않은 사진 데이터 에러",
+                    "description": "저장할 사진이 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "PHO-400",
+                        "reason": "사진 데이터가 유효하지 않습니다.",
+                        "data": {
+                          "reason": "저장할 사진이 없습니다."
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "사진 추가 에러": {
+                    "summary": "사진 추가 에러",
+                    "description": "메모 사진 추가 중 오류가 발생했습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "MEM-400",
+                        "reason": "메모 사진 추가 중 오류가 발생했습니다.",
+                        "data": {
+                          "folderId": "1",
+                          "imageUrl": "string"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "유효하지 않은 확장자 에러": {
+                    "summary": "유효하지 않은 확장자 에러",
+                    "description": "이미지 확장자가 유효하지 않습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "PHO-400",
+                        "reason": "사진 데이터가 유효하지 않습니다.",
+                        "data": {
+                          "extension": "string"
+                        }
+                      },
+                      "success": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "폴더명 중복 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-409"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "이미 존재하는 폴더 이름입니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
                     }
                   }
                 }
@@ -268,6 +2481,139 @@
                           "type": "string"
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "400"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "사진 추가 에러": {
+                    "summary": "사진 추가 에러",
+                    "description": "메모 사진 추가 중 오류가 발생했습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "MEM-400",
+                        "reason": "메모 사진 추가 중 오류가 발생했습니다.",
+                        "data": {
+                          "folderId": "1",
+                          "imageUrl": "string"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "유효하지 않은 확장자 에러": {
+                    "summary": "유효하지 않은 확장자 에러",
+                    "description": "이미지 확장자가 유효하지 않습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "PHO-400",
+                        "reason": "사진 데이터가 유효하지 않습니다.",
+                        "data": {
+                          "extension": "string"
+                        }
+                      },
+                      "success": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "조회할 수 없는 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "404"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "폴더 조회 에러": {
+                    "summary": "폴더 조회 에러",
+                    "description": "해당 폴더를 찾을 수 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "FOL-404",
+                        "reason": "해당 폴더를 찾을 수 없습니다.",
+                        "data": {
+                          "folderId": "1"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "사진 조회 에러": {
+                    "summary": "사진 조회 에러",
+                    "description": "해당 사진 데이터가 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "PHO-404",
+                        "reason": "해당 사진 데이터가 없습니다.",
+                        "data": {
+                          "reason": "저장할 사진이 없습니다."
+                        }
+                      },
+                      "success": null
                     }
                   }
                 }
@@ -441,32 +2787,73 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "유효하지 않은 입력 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "SRH-400"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "입력 데이터가 유효하지 않습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "reason": {
+                              "type": "string",
+                              "example": "검색어를 1자 이상 입력하세요."
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
     },
-    "/memo/folders/{folderId}": {
-      "get": {
+    "/memo/folders/{folderId}/images/move": {
+      "patch": {
         "tags": [
-          "memo-folder-controller"
+          "memo-image-controller"
         ],
-        "summary": "특정 폴더의 메모 조회 API",
-        "description": "특정 폴더의 모든 메모(텍스트 및 사진)을 조회하는 API입니다.",
+        "summary": "사진 이동 API",
+        "description": "특정 폴더의 사진을 이동하는 API입니다.",
         "parameters": [
           {
             "name": "folderId",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "폴더 ID 입력"
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "메모 조회 성공 응답",
+            "description": "사진 이동 성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -508,12 +2895,446 @@
                               }
                             }
                           }
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "example": "2025-01-17T03:50:25.923Z"
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "사진 이동 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "MEM-400"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "메모 사진 이동 중 오류가 발생했습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderId": {
+                              "type": "string",
+                              "example": "1"
+                            },
+                            "imageId": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "example": "1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "조회할 수 없는 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "404"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "폴더 조회 에러": {
+                    "summary": "폴더 조회 에러",
+                    "description": "해당 폴더를 찾을 수 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "FOL-404",
+                        "reason": "해당 폴더를 찾을 수 없습니다.",
+                        "data": {
+                          "folderId": "1"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "사진 조회 에러": {
+                    "summary": "사진 조회 에러",
+                    "description": "해당 사진 데이터가 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "PHO-404",
+                        "reason": "해당 사진 데이터가 없습니다.",
+                        "data": {
+                          "imageId": "1"
+                        }
+                      },
+                      "success": null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "folderId",
+                  "imageId"
+                ],
+                "properties": {
+                  "targetFolderId": {
+                    "type": "integer"
+                  },
+                  "imageId": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/memo/folders/{folderId}/text": {
+      "patch": {
+        "tags": [
+          "memo-folder-controller"
+        ],
+        "summary": "특정 폴더의 메모 텍스트 수정 API",
+        "description": "특정 폴더의 메모 텍스트를 수정하는 API입니다.",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "폴더 ID 입력"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "메모 텍스트 수정 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "SUCCESS"
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "folderId": {
+                          "type": "string",
+                          "example": "1"
+                        },
+                        "folderName": {
+                          "type": "string"
+                        },
+                        "imageText": {
+                          "type": "string"
+                        },
+                        "images": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "imageId": {
+                                "type": "string",
+                                "example": "1"
+                              },
+                              "imageUrl": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "폴더 조회 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "FOL-404"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "example": "해당 폴더를 찾을 수 없습니다."
+                        },
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "folderId": {
+                              "type": "string",
+                              "example": "1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "memoText"
+                ],
+                "properties": {
+                  "memoText": {
+                    "type": "string",
+                    "description": "메모 텍스트"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/memo/folders/{folderId}/images": {
+      "delete": {
+        "tags": [
+          "memo-image-controller"
+        ],
+        "summary": "사진 삭제 API",
+        "description": "특정 폴더의 사진을 삭제하는 API입니다.",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "폴더 ID 입력"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "사진 삭제 성공 응답",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "SUCCESS"
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "folderId": {
+                          "type": "string",
+                          "example": "1"
+                        },
+                        "folderName": {
+                          "type": "string"
+                        },
+                        "imageText": {
+                          "type": "string"
+                        },
+                        "images": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "imageId": {
+                                "type": "string",
+                                "example": "1"
+                              },
+                              "imageUrl": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "조회할 수 없는 데이터 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAIL"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "errorCode": {
+                          "type": "string",
+                          "example": "404"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "data": {}
+                      }
+                    },
+                    "success": {
+                      "type": "object",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "폴더 조회 에러": {
+                    "summary": "폴더 조회 에러",
+                    "description": "해당 폴더를 찾을 수 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "FOL-404",
+                        "reason": "해당 폴더를 찾을 수 없습니다.",
+                        "data": {
+                          "folderId": "1"
+                        }
+                      },
+                      "success": null
+                    }
+                  },
+                  "사진 조회 에러": {
+                    "summary": "사진 조회 에러",
+                    "description": "해당 사진 데이터가 없습니다.",
+                    "value": {
+                      "resultType": "FAIL",
+                      "error": {
+                        "errorCode": "PHO-404",
+                        "reason": "해당 사진 데이터가 없습니다.",
+                        "data": {
+                          "imageId": "1"
+                        }
+                      },
+                      "success": null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "imageId"
+                ],
+                "properties": {
+                  "imageId": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
                     }
                   }
                 }


### PR DESCRIPTION
- 메모 텍스트 수정 API에서 폴더 ID로 조회했을 때 null을 반환받을 경우 FolderNotFoundError 커스텀 에러 처리한다.
- 메모장의 모든 API에 대해 Swagger 문서에 400, 404, 409 에러 코드에 대한 실패 응답 예시를 작성한다.