### PR TITLE
[SWEP-86] 히스토리 API

### DIFF
--- a/src/controllers/history.controller.ts
+++ b/src/controllers/history.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Route, SuccessResponse, Tags, Request, Post} from 'tsoa';
+import { Request as ExpressRequest } from 'express';
+import { DataValidationError } from 'src/errors.js';
+import { serviceGetMostTagged, serviceNewAward } from 'src/services/history.services.js';
+import { ResponseFromMostTagToClient } from 'src/models/history.model.js';
+import {Response} from '../models/tsoaResponse.js';
+
+@Route('user')
+export class MostTaggedController extends Controller{
+    @Get('/history/most_tagged/get')
+    @Tags('History')
+    @SuccessResponse('200', 'OK')
+    public async getMostTagged(
+        @Request() req: ExpressRequest,
+    ): Promise<Response> {
+        if(!req.user){
+           throw new DataValidationError({reason: '유저 정보가 없습니다. 다시 로그인 해주세요.'});
+        }
+        const userId: bigint = req.user.id;
+
+        const result: ResponseFromMostTagToClient[] = await serviceGetMostTagged(userId);
+        
+        //console.log(result);
+
+        return new Response(result);
+    }
+}
+
+@Route('user')
+export class AwardController extends Controller{
+    @Post('/history/award/create')
+    @Tags('Award')
+    @SuccessResponse('200', 'OK')
+    public async createNewAward(
+        @Request() req: ExpressRequest
+    ): Promise<Response> {
+        try{
+            if(!req.user){
+                throw new DataValidationError({reason: '유저 정보가 없습니다.'});
+            }
+
+            serviceNewAward(req.user.id);
+        }
+        catch(error){
+            //console.error('Controller error');
+            throw error;
+        }
+
+        return new Response('success');
+    }
+}

--- a/src/dtos/history.dto.ts
+++ b/src/dtos/history.dto.ts
@@ -1,0 +1,31 @@
+import { Award } from '@prisma/client';
+import { ResponseFromMostTag, ResponseFromMostTagToClient, ResponseFromNewAward } from 'src/models/history.model.js';
+
+export const responseFromMostTag = (
+    arr: ResponseFromMostTag[]
+): ResponseFromMostTagToClient[] => {
+    return arr.map((value: ResponseFromMostTag) => {
+        const {_count, tagCategoryId, content} = value;
+        
+        return{
+            _count,
+            tagCategoryId: tagCategoryId.toString(),
+            content
+        };
+    });
+};
+
+export const responseFromNewAward = (
+    newAward: Award
+): ResponseFromNewAward => {
+    const {id, awardMonth, createdAt, updatedAt, status, userId} = newAward;
+
+    return {
+        id: id.toString(),
+        awardMonth,
+        createdAt,
+        updatedAt,
+        status,
+        userId: userId.toString()
+    };
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -194,6 +194,20 @@ export class NaverGeoCodeError extends BaseError {
   }
 }
 
+// 히스토리 관련 에러
+export class NoDataFoundError extends BaseError {
+  constructor(details: {reason: string}){
+    super(404, 'HIS-404', '조회를 요청한 데이터가 없습니다.', details);
+  }
+}
+
+// 어워드 중복 에러
+export class DuplicateAwardError extends BaseError {
+  constructor(details: {reason: string}){
+    super(400, 'HIS-400', '이미 해당 월의 어워드가 존재합니다.', details);
+  }
+}
+
 // 사진 데이터 관련 에러 (PHO-photo)
 export class PhotoDataNotFoundError extends BaseError {
   constructor(details?: ErrorDetails) {

--- a/src/models/history.model.ts
+++ b/src/models/history.model.ts
@@ -1,0 +1,24 @@
+export interface ResponseFromMostTag{
+    _count: {
+        _all: number;
+    }
+    tagCategoryId: bigint;
+    content: string;
+}
+
+export interface ResponseFromMostTagToClient{
+    _count: {
+        _all: number;
+    }
+    tagCategoryId: string;
+    content: string;
+}
+
+export interface ResponseFromNewAward{
+    id: string,
+    awardMonth: Date,
+    createdAt: Date,
+    updatedAt: Date | null,
+    status: number,
+    userId: string
+}

--- a/src/repositories/history.repositories.ts
+++ b/src/repositories/history.repositories.ts
@@ -1,0 +1,99 @@
+import { ResponseFromMostTag } from 'src/models/history.model.js';
+import {prisma} from '../db.config.js';
+import { DuplicateAwardError, NoDataFoundError } from 'src/errors.js';
+import { Award } from '@prisma/client';
+
+export const getMostTagged = async (userId: bigint): Promise<ResponseFromMostTag[]> => {
+    const currentTime: Date = new Date();
+    const currentMonth: Date = new Date(currentTime.getFullYear(), currentTime.getMonth(), 1);  //이번 달의 시작
+    const nextMonth: Date = new Date(currentTime.getFullYear() + (
+        currentTime.getMonth() === 1 
+        ? 1 
+        : 0
+    ),(currentTime.getMonth() + 1) % 12, 1); //다음 달의 시작. 12월이면 하나 올리기
+
+    const userImages = await prisma.image.findMany({
+        where: {
+            AND: [
+                {userId: userId},
+                {updatedAt: {
+                    lt: nextMonth,
+                    gte: currentMonth
+                }}
+            ]
+        },
+        select: {
+            id: true
+        }
+    });
+
+    //console.log(userImages);
+
+    if(!userImages){
+        throw new NoDataFoundError({reason: `유저 ${userId}의 이번 달 사진이 없습니다.`});
+    }
+
+    const imageTags = await prisma.imageTag.findMany({
+        where: {
+            imageId: {
+                in: userImages.map((value: {id: bigint;}) => value.id)
+            }
+        },
+        select: {
+            tagId: true
+        }
+    });
+
+    //console.log(imageTags);
+
+    const countTagCategory = await prisma.tag.groupBy({
+        by: ['tagCategoryId', 'content'],
+        orderBy:{
+            tagCategoryId: 'asc'
+        },
+        where: {
+            id: {
+                in: imageTags.map((value: {tagId: bigint;}) => value.tagId)
+            },
+            tagCategoryId: {
+                lte: 3
+            }
+        },
+        _count: {
+            _all: true
+        }
+    });
+
+    //console.log(countTagCategory);
+
+    return countTagCategory;
+};
+
+export const newUserAward = async(id: bigint): Promise<Award | null> => {
+    const currentDate: Date = new Date();
+    //console.log(currentDate);
+    currentDate.setMonth(currentDate.getMonth() + 1);
+    currentDate.setDate(1);
+    currentDate.setHours(0, 0, 0, 0);
+    //console.log(currentDate);
+
+    const isAwardExist = await prisma.award.findFirst({
+        where: {
+            userId: id,
+            awardMonth: currentDate
+        }
+    });
+
+    if(isAwardExist){
+        throw new DuplicateAwardError({reason: `${id} 유저의 ${currentDate.getMonth()}월의 어워드가 존재합니다.`});
+    }
+
+    const newAward = prisma.award.create({
+        data: {
+            userId: id,
+            awardMonth: currentDate
+        }
+    });
+
+    return newAward;
+};

--- a/src/routers/tsoaRoutes.ts
+++ b/src/routers/tsoaRoutes.ts
@@ -7,6 +7,10 @@ import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 import { TagsController } from './../controllers/tsoaTag.controller.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ImagesController } from './../controllers/tsoaImage.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { MostTaggedController } from './../controllers/history.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AwardController } from './../controllers/history.controller.js';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
 
@@ -94,6 +98,66 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'getImageListFromTag',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMostTaggedController_getMostTagged: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.get('/user/history/most_tagged/get',
+            ...(fetchMiddlewares<RequestHandler>(MostTaggedController)),
+            ...(fetchMiddlewares<RequestHandler>(MostTaggedController.prototype.getMostTagged)),
+
+            async function MostTaggedController_getMostTagged(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMostTaggedController_getMostTagged, request, response });
+
+                const controller = new MostTaggedController();
+
+              await templateService.apiHandler({
+                methodName: 'getMostTagged',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAwardController_createNewAward: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.post('/user/history/award/create',
+            ...(fetchMiddlewares<RequestHandler>(AwardController)),
+            ...(fetchMiddlewares<RequestHandler>(AwardController.prototype.createNewAward)),
+
+            async function AwardController_createNewAward(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAwardController_createNewAward, request, response });
+
+                const controller = new AwardController();
+
+              await templateService.apiHandler({
+                methodName: 'createNewAward',
                 controller,
                 response,
                 next,

--- a/src/services/history.services.ts
+++ b/src/services/history.services.ts
@@ -1,0 +1,44 @@
+import { Award } from '@prisma/client';
+import { responseFromMostTag, responseFromNewAward } from 'src/dtos/history.dto.js';
+import { DuplicateAwardError, NoDataFoundError } from 'src/errors.js';
+import { ResponseFromMostTag, ResponseFromMostTagToClient, ResponseFromNewAward } from 'src/models/history.model.js';
+import { getMostTagged, newUserAward } from 'src/repositories/history.repositories.js';
+
+
+export const serviceGetMostTagged = async (userId: bigint): Promise<ResponseFromMostTagToClient[]> => {
+    const result: ResponseFromMostTag[] = await getMostTagged(userId);
+
+    if(result === null || result.length === 0){
+        throw new NoDataFoundError({reason: `유저 ${userId}의 태그를 찾을 수 없습니다.`});
+    }
+
+    result.sort((a: ResponseFromMostTag, b: ResponseFromMostTag) =>
+        parseInt((a.tagCategoryId - b.tagCategoryId).toString()) || 
+    b._count._all - a._count._all);
+
+    //console.log(result);
+
+    let category: bigint = 1n;
+    const sortedResult: ResponseFromMostTag[] = result.filter((a: ResponseFromMostTag) => {
+        if(a.tagCategoryId === category){
+            category++;
+            return true;
+        }
+        
+        return false;
+    });
+
+    //console.log(sortedResult);
+
+    return responseFromMostTag(sortedResult);
+};
+
+export const serviceNewAward = async (id: bigint): Promise<ResponseFromNewAward> => {
+    const newAward: Award | null = await newUserAward(id);
+
+    if(newAward === null){
+        throw new DuplicateAwardError({reason: `${id} 유저의 이번 달 어워드가 존재합니다.`});
+    }
+
+    return responseFromNewAward(newAward);
+};

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -141,11 +141,26 @@
 					}
 				]
 			}
+		},
+		"/user/history/most_tagged/get": {
+			"get": {
+				"operationId": "GetMostTagged",
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"tags": [
+					"History"
+				],
+				"security": [],
+				"parameters": []
+			}
 		}
 	},
 	"servers": [
 		{
-			"url": "http://3.37.137.212:3000",
+			"url": "http://localhost:3000",
 			"description": "Sweepic server"
 		}
 	]


### PR DESCRIPTION
# Sweepic Server PR List

## ⚒️develop의 최신 커밋을 pull 받았나요?
- [ ] 최신 커밋 업데이트

## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
* 히스토리 API 중 어워드 생성, 수정, 조회, 인기 태그 조회 기능입니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요? (핵심 작업 내용)
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* 히스토리 api 파트는 tsoa로 작성하였습니다. 전반적으로 링크의 코드를 보고 양식 따라했습니다. 좋은 코드 감사드립니다 :)
* 조회 기능이 조금 복잡합니다.
```typescript
export const getMostTagged = async (userId: bigint): Promise<ResponseFromMostTag[]> => {
    const currentTime: Date = new Date();
    const currentMonth: Date = new Date(currentTime.getFullYear(), currentTime.getMonth(), 1);  //이번 달의 시작
    const nextMonth: Date = new Date(currentTime.getFullYear() + (
        currentTime.getMonth() === 1 
        ? 1 
        : 0
    ),(currentTime.getMonth() + 1) % 12, 1); //다음 달의 시작. 12월이면 하나 올리기

    const userImages = await prisma.image.findMany({
        where: {
            AND: [
                {userId: userId},
                {updatedAt: {
                    lt: nextMonth,
                    gte: currentMonth
                }}
            ]
        },
        select: {
            id: true
        }
    });

    //console.log(userImages);

    if(!userImages){
        throw new NoDataFoundError({reason: `유저 ${userId}의 이번 달 사진이 없습니다.`});
    }

    const imageTags = await prisma.imageTag.findMany({
        where: {
            imageId: {
                in: userImages.map((value: {id: bigint;}) => value.id)
            }
        },
        select: {
            tagId: true
        }
    });

    //console.log(imageTags);

    const countTagCategory = await prisma.tag.groupBy({
        by: ['tagCategoryId', 'content'],
        orderBy:{
            tagCategoryId: 'asc'
        },
        where: {
            id: {
                in: imageTags.map((value: {tagId: bigint;}) => value.tagId)
            },
            tagCategoryId: {
                lte: 3
            }
        },
        _count: {
            _all: true
        }
    });

    //console.log(countTagCategory);

    return countTagCategory;
};
```
알고리즘 흐름은 다음과 같습니다.
1. 유저의 이미지 확인 -> 이번 달에 수정된 사진들 기준입니다.
2. currentDate에서 달 정보를 수정하여 이번 달과 다음 달 사이에 있는 사진들이 조회될 수 있도록 했습니다.
3. 이미지의 목록을 image-tag 테이블에서 조회합니다. 여기서 태그들의 정보를 얻습니다.
4. tag 테이블에서 각 카테고리와 content를 기준으로 count를 하고 service로 리턴합니다. 로직은 service에서 이어집니다.

```typescript
export const serviceGetMostTagged = async (userId: bigint): Promise<ResponseFromMostTagToClient[]> => {
    const result: ResponseFromMostTag[] = await getMostTagged(userId);

    if(result === null || result.length === 0){
        throw new NoDataFoundError({reason: `유저 ${userId}의 태그를 찾을 수 없습니다.`});
    }

    result.sort((a: ResponseFromMostTag, b: ResponseFromMostTag) =>
        parseInt((a.tagCategoryId - b.tagCategoryId).toString()) || 
    b._count._all - a._count._all);

    //console.log(result);

    let category: bigint = 1n;
    const sortedResult: ResponseFromMostTag[] = result.filter((a: ResponseFromMostTag) => {
        if(a.tagCategoryId === category){
            category++;
            return true;
        }
        
        return false;
    });

    //console.log(sortedResult);

    return responseFromMostTag(sortedResult);
};
```
에러 처리 이후 배열을 sort합니다. sort의 기준은 두가지 입니다.
1. 태그의 카테고리
2. count된 동일 content 개수
카테고리가 우선이 되어서 배열의 형태는 다음과 같게 정리됩니다.
category = 1n, _count = 5
category = 1n, _count = 3
category = 1n, _count = 1
category = 2n, _count = 3
category = 2n, _count = 1
정리하자면 카테고리 별로 가장 먼저 있는 요소가 가장 많은(인기있는) 태그인 겁니다.

정렬된 배열을 let category = 1n이라는 변수를 기준으로 순회합니다. Array.filter() 기능을 활용해 조건에 만족하는 요소만 
return하여 새로운 sortedResult라는 배열을 최종적으로 반환합니다.

그 외 API들은 어워드와 어워드를 수정하고 조회하는 기능을 수행합니다.
수정 API는 repository에서 기존 항목을 award-image 테이블에서 삭제하고 다시 등록하는 형식으로 만들었습니다.
원래는 award-image 테이블의 생성,  수정 api를 따로 만들려고 했으나 그렇게 제작하면 프론트에서 연결하기 어려워질 것 같아
삭제시키는 방향으로 갔습니다.
```typescript
export const updateAwardImage = async (userId: bigint, awardId: bigint, imageId: bigint[]): Promise<AwardImage[]> => {
    if(imageId.length !== 5){
        throw new AwardImageError({reason: `${imageId.length}는 올바른 이미지 개수가 아닙니다. 
            총 5개의 이미지가 필요합니다.`});
    }
    
    const verifyImages = await prisma.image.findMany({
        where: {
            userId: userId,
            mediaId: {
                in: imageId
            }
        }
    });

    if(verifyImages === null || verifyImages.length === 0){
        throw new NoDataFoundError({reason: `${userId} 유저의 ${imageId} 이미지를 찾을 수 없습니다.`});
    }

    await prisma.awardImage.deleteMany({
        where: {
            awardId: awardId
        }
    });

    for(let i = 0; i < verifyImages.length; i++){
        await prisma.awardImage.create({
            data: {
                imageId: verifyImages[i].id,
                awardId: awardId
            }
        });
    }

    const result = await prisma.awardImage.findMany({
        where: {
            awardId: awardId
        }
    });

    return result;
};
```
저희 기능상 하나의 어워드에는 이미지가 5개 할당되므로 이미지의 개수가 맞지 않으면 곧바로 에러처리합니다.

## 🤚 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스크린 샷을 올려주세요
* 
![yarn](https://github.com/user-attachments/assets/3931e312-b4c8-4c30-8a0e-1aed89ed8adb)
![mosttag](https://github.com/user-attachments/assets/ff298de9-5e97-4d96-99be-eb436a86c121)
조회하는 요청이 많아서 처리시간이 걱정되었는데 다행히 큰 영향은 없는 것 같습니다.
![createaward](https://github.com/user-attachments/assets/131933bc-15d2-4143-b202-9f0b028688b6)
![awardget](https://github.com/user-attachments/assets/8609c445-d43e-469f-9d27-1cc23caf5727)
![updateaward](https://github.com/user-attachments/assets/cb0582f8-d835-44b8-890e-4e8dfa8c671a)
![swagger](https://github.com/user-attachments/assets/7bc1c108-7464-46ba-843a-ecfc4906e4b1)
스웨거 잘 뜹니다.


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 기존 챌린지 api와는 달리 로그인 상태를 전제로 제작하였습니다. 따라서 api 테스트시 postman이나 swagger에서 세션이 유지되어야 합니다. user는 13번 id(본인)를 사용하였으므로 더미데이터가 부족할 수 있습니다. 만약 에러가 발생한다면 데이터베이스에 테스트용 데이터를 충분히 생성하셔야 합니다.

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
* 조금 서두른 감이 있어서 테스트 중 에러가 많이 발생..할수도 있습니다. 만약 테스트 도중 에러가 발생한다면 예시 데이터와 에러 코드 알려주시면 빠르게 수정하겠습니다.

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
* swagger로 tsoa 변환 결과 확인했는데 잘 되는 것 같습니다.(드디어!) 근데 swagger로 세션 유지 어떻게 하나요? postman으로는 하고 있는데 swagger는 계속 인증에러 납니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **2일 이내**에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item
