### PR TITLE
[SWEP-87] 챌린지 API 개선

### DIFF
--- a/src/controllers/challenge.controllers.ts
+++ b/src/controllers/challenge.controllers.ts
@@ -8,7 +8,6 @@ import {
 } from '../services/challenge.services.js';
 import {StatusCodes} from 'http-status-codes';
 import {
-  getIdNumber,
   getReverseGeocode
 } from '../utils/challenge.utils.js';
 import {Challenge} from '@prisma/client';
@@ -67,7 +66,7 @@ export const handleUpdateChallenge = async (
       throw new DataValidationError({reason: '업데이트 내용이 없습니다.'});
     }
 
-    serviceUpdateChallenge(req.body);
+    await serviceUpdateChallenge(req.body);
     res.status(StatusCodes.OK).success(req.body);
   } catch (error) {
     next(error);
@@ -75,7 +74,7 @@ export const handleUpdateChallenge = async (
 };
 
 export const handleRemoveChallenge = async (
-  req: Request,
+  req: Request<{id: string}>,
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
@@ -84,18 +83,7 @@ export const handleRemoveChallenge = async (
     #swagger.summary = '챌린지 삭제 API';
     #swagger.description = '챌린지를 삭제하는 API입니다.';
     #swagger.requestBody = {
-        required: true,
-        content: {
-            "application/json": {
-                schema: {
-                    type: "object",
-                    required: ['id'],
-                    properties: {
-                        id: { type: "string", description: "챌린지 ID" }
-                    }
-                }
-            }
-        }
+        required: false
     };
     #swagger.responses[200] = {
         description: "챌린지 삭제 성공 응답",
@@ -119,13 +107,13 @@ export const handleRemoveChallenge = async (
     };
     */
   try {
-    if (!req.body) {
+    if (!req.params.id) {
       throw new DataValidationError({
         reason: '삭제할 챌린지의 정보가 없습니다.',
       });
     }
-    serviceDeleteChallenge(getIdNumber(req.body));
-    res.status(StatusCodes.OK).success(req.body);
+    await serviceDeleteChallenge(BigInt(req.params.id));
+    res.status(StatusCodes.OK).success(BigInt(req.params.id));
   } catch (error) {
     next(error);
   }
@@ -266,7 +254,7 @@ export const handleCompleteChallenge = async (
 };
 
 export const handleGetByUserId = async (
-  req: Request<{userId: string}>,
+  req: Request,
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
@@ -325,7 +313,7 @@ export const handleGetByUserId = async (
         if(req.user === null || req.user === undefined){
             throw new DataValidationError({reason: 'req.user 정보가 없습니다.'});
         }
-        const result: ResponseFromGetByUserIdReform[] = await serviceGetByUserId(BigInt(req.user.id));
+        const result: ResponseFromGetByUserIdReform[] = await serviceGetByUserId(req.user.id);
         res.status(StatusCodes.OK).success(result);
     } catch(error){
         next(error);

--- a/src/controllers/challenge.location.controllers.ts
+++ b/src/controllers/challenge.location.controllers.ts
@@ -28,8 +28,6 @@ export const handleNewLocationChallenge = async (
                 schema: {
                     type: "object",
                     properties: {
-                        userId: { type: "string", description: "유저 Id" },
-                        title: { type: "string", description: "챌린지 제목" },
                         context: { type: "string", description: "챌린지 내용" },
                         location: { type: "string", description: "챌린지 위치" },
                         required: { type: "number", description: "챌린지 장수" }
@@ -70,13 +68,17 @@ export const handleNewLocationChallenge = async (
     };
     */
   try {
+    if(!req.user){
+      throw new DataValidationError({reason: '유저 정보가 없습니다. 다시 로그인 해주세요.'});
+    }
+
     if (!req.body) {
       throw new DataValidationError({
         reason: '위치 챌린지를 생성할 데이터가 없습니다.',
       });
     }
 
-    const data: LocationChallengeCreation = bodyToLocationCreation(req.body);
+    const data: LocationChallengeCreation = bodyToLocationCreation(req.body, req.user.id);
     const result: ResponseFromChallenge =
       await serviceCreateNewLocationChallenge(data);
     res.status(StatusCodes.OK).success(result);

--- a/src/controllers/challenge.weekly.controllers.ts
+++ b/src/controllers/challenge.weekly.controllers.ts
@@ -27,8 +27,6 @@ export const handleNewWeeklyChallenge = async (
                 schema: {
                     type: "object",
                     properties: {
-                        userId: { type: "string", description: "유저 Id" },
-                        title: { type: "string", description: "챌린지 제목" },
                         context: { type: "string", description: "챌린지 내용" },
                         challengeDate: { type: "string", format: "date-time", description: "챌린지 날짜" },
                         required: { type: "number", description: "챌린지 장수" }
@@ -69,13 +67,17 @@ export const handleNewWeeklyChallenge = async (
     };
     */
   try {
+    if(!req.user){
+      throw new DataValidationError({reason: '유저 정보가 없습니다. 다시 로그인 해주세요.'});
+    }
+
     if (!req.body) {
       throw new DataValidationError({
         reason: '날짜 챌린지를 생성할 데이터가 없습니다.',
       });
     }
 
-    const data: WeeklyChallengeCreation = bodyToWeeklyCreation(req.body);
+    const data: WeeklyChallengeCreation = bodyToWeeklyCreation(req.body, req.user.id);
     const result: ResponseFromChallenge =
       await serviceCreateNewWeeklyChallenge(data);
     res.status(StatusCodes.OK).success(result);

--- a/src/controllers/history.controller.ts
+++ b/src/controllers/history.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Route, SuccessResponse, Tags, Request, Post} from 'tsoa';
+import { Request as ExpressRequest } from 'express';
+import { DataValidationError } from 'src/errors.js';
+import { serviceGetMostTagged, serviceNewAward } from 'src/services/history.services.js';
+import { ResponseFromMostTagToClient } from 'src/models/history.model.js';
+import {Response} from '../models/tsoaResponse.js';
+
+@Route('user')
+export class MostTaggedController extends Controller{
+    @Get('/history/most_tagged/get')
+    @Tags('History')
+    @SuccessResponse('200', 'OK')
+    public async getMostTagged(
+        @Request() req: ExpressRequest,
+    ): Promise<Response> {
+        if(!req.user){
+           throw new DataValidationError({reason: '유저 정보가 없습니다. 다시 로그인 해주세요.'});
+        }
+        const userId: bigint = req.user.id;
+
+        const result: ResponseFromMostTagToClient[] = await serviceGetMostTagged(userId);
+        
+        //console.log(result);
+
+        return new Response(result);
+    }
+}
+
+@Route('user')
+export class AwardController extends Controller{
+    @Post('/history/award/create')
+    @Tags('Award')
+    @SuccessResponse('200', 'OK')
+    public async createNewAward(
+        @Request() req: ExpressRequest
+    ): Promise<Response> {
+        try{
+            if(!req.user){
+                throw new DataValidationError({reason: '유저 정보가 없습니다.'});
+            }
+
+            serviceNewAward(req.user.id);
+        }
+        catch(error){
+            //console.error('Controller error');
+            throw error;
+        }
+
+        return new Response('success');
+    }
+}

--- a/src/dtos/challenge.dtos.ts
+++ b/src/dtos/challenge.dtos.ts
@@ -108,11 +108,11 @@ export const bodyToLocationLogic = (photo: PhotoInfo[]): PhotoInfo[] => {
     return photo;
 };
 
-export const bodyToLocationCreation = (data: BodyToLocationCreation) => {
-    const {userId, title, context, location, required} = data;
+export const bodyToLocationCreation = (data: BodyToLocationCreation, userId: bigint) => {
+    const {title, context, location, required} = data;
     
     return {
-        userId: BigInt(userId),
+        userId: userId,
         title,
         context,
         location,
@@ -120,11 +120,11 @@ export const bodyToLocationCreation = (data: BodyToLocationCreation) => {
     };
 };
 
-export const bodyToWeeklyCreation = (data: BodyToWeeklyCreation) => {
-    const {userId, title, context, challengeDate, required} = data;
+export const bodyToWeeklyCreation = (data: BodyToWeeklyCreation, userId: bigint) => {
+    const {title, context, challengeDate, required} = data;
 
     return {
-        userId: BigInt(userId),
+        userId: userId,
         title,
         context,
         challengeDate,

--- a/src/dtos/history.dto.ts
+++ b/src/dtos/history.dto.ts
@@ -1,0 +1,31 @@
+import { Award } from '@prisma/client';
+import { ResponseFromMostTag, ResponseFromMostTagToClient, ResponseFromNewAward } from 'src/models/history.model.js';
+
+export const responseFromMostTag = (
+    arr: ResponseFromMostTag[]
+): ResponseFromMostTagToClient[] => {
+    return arr.map((value: ResponseFromMostTag) => {
+        const {_count, tagCategoryId, content} = value;
+        
+        return{
+            _count,
+            tagCategoryId: tagCategoryId.toString(),
+            content
+        };
+    });
+};
+
+export const responseFromNewAward = (
+    newAward: Award
+): ResponseFromNewAward => {
+    const {id, awardMonth, createdAt, updatedAt, status, userId} = newAward;
+
+    return {
+        id: id.toString(),
+        awardMonth,
+        createdAt,
+        updatedAt,
+        status,
+        userId: userId.toString()
+    };
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -221,7 +221,7 @@ export class ChallengeCompleteError extends BaseError {
 
 // 챌린지 조회 관련 에러 (CHL)
 export class ChallengeNotFoundError extends BaseError {
-  constructor(details: {userId: bigint}) {
+  constructor(details: {userId: bigint; reason?: string}) {
     const errorDetails = {
       userId: details.userId.toString(),
     };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -194,6 +194,20 @@ export class NaverGeoCodeError extends BaseError {
   }
 }
 
+// 히스토리 관련 에러
+export class NoDataFoundError extends BaseError {
+  constructor(details: {reason: string}){
+    super(404, 'HIS-404', '조회를 요청한 데이터가 없습니다.', details);
+  }
+}
+
+// 어워드 중복 에러
+export class DuplicateAwardError extends BaseError {
+  constructor(details: {reason: string}){
+    super(400, 'HIS-400', '이미 해당 월의 어워드가 존재합니다.', details);
+  }
+}
+
 // 사진 데이터 관련 에러 (PHO-photo)
 export class PhotoDataNotFoundError extends BaseError {
   constructor(details?: ErrorDetails) {

--- a/src/models/challenge.entities.ts
+++ b/src/models/challenge.entities.ts
@@ -1,14 +1,12 @@
 export interface BodyToLocationCreation {
-    userId: string;
-    title: string;
+    title: string | null;
     context: string;
     location: string;
     required: number;
 }
 
 export interface BodyToWeeklyCreation {
-    userId: string;
-    title: string;
+    title: string | null;
     context: string;
     challengeDate: Date;
     required: number;
@@ -16,7 +14,7 @@ export interface BodyToWeeklyCreation {
 
 export interface LocationChallengeCreation {
     userId: bigint;
-    title: string;
+    title: string | null;
     context: string;
     location: string;
     required: number;
@@ -24,7 +22,7 @@ export interface LocationChallengeCreation {
 
 export interface WeeklyChallengeCreation {
     userId: bigint;
-    title: string;
+    title: string | null;
     context: string;
     challengeDate: Date;
     required: number;

--- a/src/models/history.model.ts
+++ b/src/models/history.model.ts
@@ -1,0 +1,24 @@
+export interface ResponseFromMostTag{
+    _count: {
+        _all: number;
+    }
+    tagCategoryId: bigint;
+    content: string;
+}
+
+export interface ResponseFromMostTagToClient{
+    _count: {
+        _all: number;
+    }
+    tagCategoryId: string;
+    content: string;
+}
+
+export interface ResponseFromNewAward{
+    id: string,
+    awardMonth: Date,
+    createdAt: Date,
+    updatedAt: Date | null,
+    status: number,
+    userId: string
+}

--- a/src/repositories/challenge.repositories.ts
+++ b/src/repositories/challenge.repositories.ts
@@ -1,5 +1,10 @@
 import {prisma} from '../db.config.js';
-import {ChallengeAcceptError, ChallengeCompleteError} from '../errors.js';
+import {
+  ChallengeAcceptError, 
+  ChallengeCompleteError, 
+  ChallengeDeletionError, 
+  ChallengeUpdateError
+} from '../errors.js';
 import {
   ChallengeModify,
   LocationChallengeCreation,
@@ -10,21 +15,10 @@ import {Challenge, LocationChallenge} from '@prisma/client';
 export const newLocationChallenge = async (
   data: LocationChallengeCreation,
 ): Promise<Challenge | null> => {
-  const existingChallenge = await prisma.challenge.findFirst({
-    where: {
-      userId: data.userId,
-      title: data.title,
-    },
-  });
-
-  if (existingChallenge) {
-    return null;
-  }
-
   const newChal = await prisma.challenge.create({
     data: {
       userId: data.userId,
-      title: data.title,
+      title: `${data.location}에서의 사진 챌린지!`,
       context: data.context,
       requiredCount: data.required,
       remainingCount: data.required,
@@ -46,6 +40,14 @@ export const newLocationChallenge = async (
 export const updateChallenge = async (
   data: ChallengeModify,
 ): Promise<Challenge> => {
+  const isExistChallenge = await prisma.challenge.findFirst({
+    where: {id: data.id}
+  });
+
+  if(!isExistChallenge){
+    throw new ChallengeUpdateError({challengeId: data.id});
+  }
+
   const updated = await prisma.challenge.update({
     where: {id: data.id},
     data: {
@@ -58,6 +60,14 @@ export const updateChallenge = async (
 };
 
 export const deleteChallenge = async (data: bigint): Promise<bigint> => {
+  const isExistChallenge = await prisma.challenge.findFirst({
+    where: {id: data}
+  });
+
+  if(!isExistChallenge){
+    throw new ChallengeDeletionError({challengeId: data});
+  }
+  
   const deleted = await prisma.challenge.delete({
     where: {id: data},
   });

--- a/src/repositories/history.repositories.ts
+++ b/src/repositories/history.repositories.ts
@@ -1,0 +1,99 @@
+import { ResponseFromMostTag } from 'src/models/history.model.js';
+import {prisma} from '../db.config.js';
+import { DuplicateAwardError, NoDataFoundError } from 'src/errors.js';
+import { Award } from '@prisma/client';
+
+export const getMostTagged = async (userId: bigint): Promise<ResponseFromMostTag[]> => {
+    const currentTime: Date = new Date();
+    const currentMonth: Date = new Date(currentTime.getFullYear(), currentTime.getMonth(), 1);  //이번 달의 시작
+    const nextMonth: Date = new Date(currentTime.getFullYear() + (
+        currentTime.getMonth() === 1 
+        ? 1 
+        : 0
+    ),(currentTime.getMonth() + 1) % 12, 1); //다음 달의 시작. 12월이면 하나 올리기
+
+    const userImages = await prisma.image.findMany({
+        where: {
+            AND: [
+                {userId: userId},
+                {updatedAt: {
+                    lt: nextMonth,
+                    gte: currentMonth
+                }}
+            ]
+        },
+        select: {
+            id: true
+        }
+    });
+
+    //console.log(userImages);
+
+    if(!userImages){
+        throw new NoDataFoundError({reason: `유저 ${userId}의 이번 달 사진이 없습니다.`});
+    }
+
+    const imageTags = await prisma.imageTag.findMany({
+        where: {
+            imageId: {
+                in: userImages.map((value: {id: bigint;}) => value.id)
+            }
+        },
+        select: {
+            tagId: true
+        }
+    });
+
+    //console.log(imageTags);
+
+    const countTagCategory = await prisma.tag.groupBy({
+        by: ['tagCategoryId', 'content'],
+        orderBy:{
+            tagCategoryId: 'asc'
+        },
+        where: {
+            id: {
+                in: imageTags.map((value: {tagId: bigint;}) => value.tagId)
+            },
+            tagCategoryId: {
+                lte: 3
+            }
+        },
+        _count: {
+            _all: true
+        }
+    });
+
+    //console.log(countTagCategory);
+
+    return countTagCategory;
+};
+
+export const newUserAward = async(id: bigint): Promise<Award | null> => {
+    const currentDate: Date = new Date();
+    //console.log(currentDate);
+    currentDate.setMonth(currentDate.getMonth() + 1);
+    currentDate.setDate(1);
+    currentDate.setHours(0, 0, 0, 0);
+    //console.log(currentDate);
+
+    const isAwardExist = await prisma.award.findFirst({
+        where: {
+            userId: id,
+            awardMonth: currentDate
+        }
+    });
+
+    if(isAwardExist){
+        throw new DuplicateAwardError({reason: `${id} 유저의 ${currentDate.getMonth()}월의 어워드가 존재합니다.`});
+    }
+
+    const newAward = prisma.award.create({
+        data: {
+            userId: id,
+            awardMonth: currentDate
+        }
+    });
+
+    return newAward;
+};

--- a/src/repositories/weekly.repositories.ts
+++ b/src/repositories/weekly.repositories.ts
@@ -5,21 +5,13 @@ import {prisma} from '../db.config.js';
 export const newWeeklyChallenge = async (
   data: WeeklyChallengeCreation,
 ): Promise<Challenge | null> => {
-  const isExisting = await prisma.challenge.findFirst({
-    where: {
-      userId: data.userId,
-      title: data.title,
-    },
-  });
-
-  if (isExisting) {
-    return null;
-  }
-
+  const currentDate: Date = new Date();
+  const day: string = `${currentDate.getFullYear()}년 ${currentDate.getMonth() + 1}월 ${currentDate.getDate()}일 사진 챌린지!`;
+  
   const newChallenge = await prisma.challenge.create({
     data: {
       userId: data.userId,
-      title: data.title,
+      title: day,
       context: data.context,
       requiredCount: data.required,
       remainingCount: data.required,
@@ -29,7 +21,7 @@ export const newWeeklyChallenge = async (
   await prisma.dateChallenge.create({
     data: {
       challengeId: newChallenge.id,
-      challengeDate: data.challengeDate,
+      challengeDate: currentDate,
     },
   });
 

--- a/src/routers/challenge.router.ts
+++ b/src/routers/challenge.router.ts
@@ -5,7 +5,7 @@ import { handleUpdateChallenge, handleRemoveChallenge, handleAcceptChallenge, ha
 import { handleGetWeeklyChallenge, handleNewWeeklyChallenge } from '../controllers/challenge.weekly.controllers.js';
 
 challengeRouter.patch('/update', handleUpdateChallenge);
-challengeRouter.delete('/delete', handleRemoveChallenge);
+challengeRouter.delete('/delete/:id', handleRemoveChallenge);
 challengeRouter.patch('/accept/:id', handleAcceptChallenge);
 challengeRouter.patch('/complete/:id', handleCompleteChallenge);
 challengeRouter.get('/get', handleGetByUserId);

--- a/src/routers/tsoaRoutes.ts
+++ b/src/routers/tsoaRoutes.ts
@@ -7,6 +7,10 @@ import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 import { TagsController } from './../controllers/tsoaTag.controller.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ImagesController } from './../controllers/tsoaImage.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { MostTaggedController } from './../controllers/history.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AwardController } from './../controllers/history.controller.js';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
 
@@ -94,6 +98,66 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'getImageListFromTag',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMostTaggedController_getMostTagged: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.get('/user/history/most_tagged/get',
+            ...(fetchMiddlewares<RequestHandler>(MostTaggedController)),
+            ...(fetchMiddlewares<RequestHandler>(MostTaggedController.prototype.getMostTagged)),
+
+            async function MostTaggedController_getMostTagged(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMostTaggedController_getMostTagged, request, response });
+
+                const controller = new MostTaggedController();
+
+              await templateService.apiHandler({
+                methodName: 'getMostTagged',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAwardController_createNewAward: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.post('/user/history/award/create',
+            ...(fetchMiddlewares<RequestHandler>(AwardController)),
+            ...(fetchMiddlewares<RequestHandler>(AwardController.prototype.createNewAward)),
+
+            async function AwardController_createNewAward(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAwardController_createNewAward, request, response });
+
+                const controller = new AwardController();
+
+              await templateService.apiHandler({
+                methodName: 'createNewAward',
                 controller,
                 response,
                 next,

--- a/src/services/challenge.location.services.ts
+++ b/src/services/challenge.location.services.ts
@@ -14,7 +14,7 @@ import {
   responseFromChallenge,
   responseFromLocationChallenge,
 } from '../dtos/challenge.dtos.js';
-import {getHashedLocation} from '../utils/challenge.utils.js';
+import {getHashedLocation, getReverseGeocode} from '../utils/challenge.utils.js';
 import {
   LocationChallengeCreationError,
   LocationChallengeNotFoundError,
@@ -25,6 +25,7 @@ export const serviceCreateNewLocationChallenge = async (
   data: LocationChallengeCreation,
 ): Promise<ResponseFromChallenge> => {
   try {
+    data.location = await getReverseGeocode(data.location);
     const newChallenge: Challenge | null = await newLocationChallenge(data);
     if (newChallenge === null) {
       throw new LocationChallengeCreationError({

--- a/src/services/history.services.ts
+++ b/src/services/history.services.ts
@@ -1,0 +1,44 @@
+import { Award } from '@prisma/client';
+import { responseFromMostTag, responseFromNewAward } from 'src/dtos/history.dto.js';
+import { DuplicateAwardError, NoDataFoundError } from 'src/errors.js';
+import { ResponseFromMostTag, ResponseFromMostTagToClient, ResponseFromNewAward } from 'src/models/history.model.js';
+import { getMostTagged, newUserAward } from 'src/repositories/history.repositories.js';
+
+
+export const serviceGetMostTagged = async (userId: bigint): Promise<ResponseFromMostTagToClient[]> => {
+    const result: ResponseFromMostTag[] = await getMostTagged(userId);
+
+    if(result === null || result.length === 0){
+        throw new NoDataFoundError({reason: `유저 ${userId}의 태그를 찾을 수 없습니다.`});
+    }
+
+    result.sort((a: ResponseFromMostTag, b: ResponseFromMostTag) =>
+        parseInt((a.tagCategoryId - b.tagCategoryId).toString()) || 
+    b._count._all - a._count._all);
+
+    //console.log(result);
+
+    let category: bigint = 1n;
+    const sortedResult: ResponseFromMostTag[] = result.filter((a: ResponseFromMostTag) => {
+        if(a.tagCategoryId === category){
+            category++;
+            return true;
+        }
+        
+        return false;
+    });
+
+    //console.log(sortedResult);
+
+    return responseFromMostTag(sortedResult);
+};
+
+export const serviceNewAward = async (id: bigint): Promise<ResponseFromNewAward> => {
+    const newAward: Award | null = await newUserAward(id);
+
+    if(newAward === null){
+        throw new DuplicateAwardError({reason: `${id} 유저의 이번 달 어워드가 존재합니다.`});
+    }
+
+    return responseFromNewAward(newAward);
+};

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -141,11 +141,26 @@
 					}
 				]
 			}
+		},
+		"/user/history/most_tagged/get": {
+			"get": {
+				"operationId": "GetMostTagged",
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"tags": [
+					"History"
+				],
+				"security": [],
+				"parameters": []
+			}
 		}
 	},
 	"servers": [
 		{
-			"url": "http://3.37.137.212:3000",
+			"url": "http://localhost:3000",
 			"description": "Sweepic server"
 		}
 	]


### PR DESCRIPTION
# Sweepic Server PR List

## ⚒️develop의 최신 커밋을 pull 받았나요?
- [ ] 최신 커밋 업데이트

## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
* userId를 프런트에서 입력받아 오는 API들을 수정했습니다. 이제 로그인 상태에서는 req.user.id로 아이디를 불러옵니다.
* 일부 챌린지 에러에서 미들웨어로 넘어가지 않는 현상을 해결했습니다.
* 챌린지 제목을 프런트에서 입력할 필요가 없어졌습니다. 챌린지 내용과 연결지어서 자동 생성되게 만들었습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요? (핵심 작업 내용)
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
1.
```typescript
  try {
    if(!req.user){
      throw new DataValidationError({reason: '유저 정보가 없습니다. 다시 로그인 해주세요.'});
    }

    if (!req.body) {
      throw new DataValidationError({
        reason: '날짜 챌린지를 생성할 데이터가 없습니다.',
      });
    }

    const data: WeeklyChallengeCreation = bodyToWeeklyCreation(req.body, req.user.id);
    const result: ResponseFromChallenge =
      await serviceCreateNewWeeklyChallenge(data);
    res.status(StatusCodes.OK).success(result);
  } catch (error) {
    next(error);
  }
```
챌린지 생성 컨트롤러 내부
이제 req.user에 대해 데이터를 가져오고 req.user.id로 챌린지를 만듭니다. req.body로 나머지 세부사항을 불러옵니다.
그리고 챌린지 제목을 프런트에서 받지 않으므로 bodyTo*Creation 함수에서 title을 없애고 인터페이스에서는
title: string | null로 임시적으로 사용하지 않게 했습니다. 입력을 받아올 수는 있다만 적용되지는 않습니다.

2.
```typescript
export const deleteChallenge = async (data: bigint): Promise<bigint> => {
  const isExistChallenge = await prisma.challenge.findFirst({
    where: {id: data}
  });

  if(!isExistChallenge){
    throw new ChallengeDeletionError({challengeId: data});
  }
  
  const deleted = await prisma.challenge.delete({
    where: {id: data},
  });

  return deleted.id;
};
```
이제 챌린지를 삭제하고 업데이트하는 repository 함수에서 챌린지 존재 유무를 먼저 파악하고 오류코드를 부여합니다.

3.
```typescript
export const newLocationChallenge = async (
  data: LocationChallengeCreation,
): Promise<Challenge | null> => {
  const newChal = await prisma.challenge.create({
    data: {
      userId: data.userId,
      title: `${data.location}에서의 사진 챌린지!`,
      context: data.context,
      requiredCount: data.required,
      remainingCount: data.required,
    },
  });

  const newId = newChal.id;

  await prisma.locationChallenge.create({
    data: {
      challengeId: newId,
      challengeLocation: data.location,
    },
  });

  return newChal;
};
```
프런트 요청에 따라 제목을 받아오지 않습니다. 대신 연관된 챌린지 정보로 제목을 설정합니다.
이와 연관해서 service에서 네이버 api를 미리 사용하도록 수정했습니다. 네이버 api 함수는 따로 위치 정보를 불러올 경우를 대비해 유지합니다.
```typescript
export const serviceCreateNewLocationChallenge = async (
  data: LocationChallengeCreation,
): Promise<ResponseFromChallenge> => {
  try {
    data.location = await getReverseGeocode(data.location);
    const newChallenge: Challenge | null = await newLocationChallenge(data);
    if (newChallenge === null) {
      throw new LocationChallengeCreationError({
        reason: '이미 존재하는 챌린지입니다.',
      });
    }

    return responseFromChallenge(newChallenge);
  } catch (error) {
    throw error;
  }
};
```

4.
```typescript
export const handleRemoveChallenge = async (
  req: Request<{id: string}>,
  res: Response,
  next: NextFunction,
): Promise<void> => {
```
이제 delete에서 json으로 받아오지 않고 params로 받아옵니다.

## 🤚 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스크린 샷을 올려주세요
*
![yarn](https://github.com/user-attachments/assets/04a42ce0-b68c-488f-95b3-f716cf978257)
![fixupdate](https://github.com/user-attachments/assets/a3bb7488-b077-4d79-a094-8a82cc6b0a9b)
![fixednewlocation](https://github.com/user-attachments/assets/7c49877e-830d-4434-afe8-f96bfb7c71bb)
![fixednewdate](https://github.com/user-attachments/assets/8fe31f6f-8259-42d8-a96b-b7e2e8d00f64)
![fixdelete](https://github.com/user-attachments/assets/ed327dc9-7d73-4468-a401-4b89118f1502)


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
*

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
*

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
*

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **2일 이내**에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item
