### PR TITLE
refactor: 메모 폴더명 공백 입력 시 에러 처리

### DIFF
--- a/src/controllers/tsoa.memo-folder.controller.ts
+++ b/src/controllers/tsoa.memo-folder.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '../services/memo-folder.service.tsoa.js';
 import {memoImageDelete} from '../services/memo-image.service.tsoa.js';
 import {bodyToMemoImagesToDelete} from '../dtos/memo-image.dto.tsoa.js';
-import {DataValidationError} from '../errors.js';
+import {DataValidationError, FolderValidationError} from '../errors.js';
 import {
   Response,
   Body,
@@ -194,6 +194,19 @@ export class MemoFolderController extends Controller {
       data: {folderName: 'string'},
     },
   })
+  @Response<ITsoaErrorResponse>(
+    StatusCodes.BAD_REQUEST,
+    '유효하지 않은 데이터 에러',
+    {
+      resultType: 'FAIL',
+      success: null,
+      error: {
+        errorCode: 'FOL-400',
+        reason: '폴더명을 1자 이상 입력해야 합니다.',
+        data: {folderName: ''},
+      },
+    },
+  )
   @SuccessResponse(StatusCodes.OK, '폴더 생성 성공 응답')
   @Example({
     resultType: 'SUCCESS',
@@ -209,6 +222,11 @@ export class MemoFolderController extends Controller {
   ): Promise<ITsoaSuccessResponse<MemoFolderResponseDto>> {
     try {
       const userId = BigInt(req.user!.id);
+      if (body.folderName === null || body.folderName.trim().length === 0) {
+        throw new FolderValidationError({
+          folderName: body.folderName,
+        });
+      }
       const memoFolder = await memoFolderCreate(userId, bodyToMemoFolder(body));
       return new TsoaSuccessResponse(memoFolder);
     } catch (error) {
@@ -507,6 +525,32 @@ export class MemoFolderController extends Controller {
       data: {folderName: 'string'},
     },
   })
+  @Response<ITsoaErrorResponse>(
+    StatusCodes.BAD_REQUEST,
+    '유효하지 않은 검색 키워드 에러',
+    {
+      resultType: 'FAIL',
+      success: null,
+      error: {
+        errorCode: 'FOL-400',
+        reason: '입력 데이터가 유효하지 않습니다.',
+        data: {folderName: ' '},
+      },
+    },
+  )
+  @Response<ITsoaErrorResponse>(
+    StatusCodes.BAD_REQUEST,
+    '유효하지 않은 데이터 에러',
+    {
+      resultType: 'FAIL',
+      success: null,
+      error: {
+        errorCode: 'FOL-400',
+        reason: '폴더명을 1자 이상 입력해야 합니다.',
+        data: {folderName: ''},
+      },
+    },
+  )
   @SuccessResponse(StatusCodes.OK, '폴더 이름 수정 성공 응답')
   @Example({
     resultType: 'SUCCESS',
@@ -530,6 +574,11 @@ export class MemoFolderController extends Controller {
   ): Promise<ITsoaSuccessResponse<MemoTextImageListResponseDto>> {
     try {
       const userId = BigInt(req.user!.id);
+      if (body.folderName === null || body.folderName.trim().length === 0) {
+        throw new FolderValidationError({
+          folderName: body.folderName,
+        });
+      }
       const folderId = BigInt(folderIdParam);
       const updatedMemoFolder = await memoFolderUpdate(
         userId,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,6 +72,12 @@ export class FolderDuplicateError extends BaseError {
   }
 }
 
+export class FolderValidationError extends BaseError {
+  constructor(details: {folderName: string}) {
+    super(400, 'FOL-400', '폴더명을 1자 이상 입력해야 합니다.', details);
+  }
+}
+
 export class FolderNotChangeError extends BaseError {
   constructor(details: {folderId: bigint}) {
     const errorDetails = {
@@ -275,28 +281,28 @@ export class NaverGeoCodeError extends BaseError {
 
 // 히스토리 관련 에러
 export class NoDataFoundError extends BaseError {
-  constructor(details: {reason: string}){
+  constructor(details: {reason: string}) {
     super(404, 'HIS-404', '조회를 요청한 데이터가 없습니다.', details);
   }
 }
 
 // 어워드 중복 에러
 export class DuplicateAwardError extends BaseError {
-  constructor(details: {reason: string}){
+  constructor(details: {reason: string}) {
     super(400, 'HIS-400', '이미 해당 월의 어워드가 존재합니다.', details);
   }
 }
 
 // 어워드 업데이트 에러
 export class AwardUpdateError extends BaseError {
-  constructor(details: {reason: string}){
+  constructor(details: {reason: string}) {
     super(400, 'HIS-400', '어워드 업데이트를 실패했습니다.', details);
   }
 }
 
 // 어워드 사진 에러
 export class AwardImageError extends BaseError {
-  constructor(details: {reason: string}){
+  constructor(details: {reason: string}) {
     super(400, 'HIS-400', '어워드 사진 형식이 잘못되었습니다.', details);
   }
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2214,6 +2214,32 @@
 												}
 											}
 										}
+									},
+									"Example 3": {
+										"value": {
+											"resultType": "FAIL",
+											"success": null,
+											"error": {
+												"errorCode": "FOL-400",
+												"reason": "입력 데이터가 유효하지 않습니다.",
+												"data": {
+													"folderName": " "
+												}
+											}
+										}
+									},
+									"Example 4": {
+										"value": {
+											"resultType": "FAIL",
+											"success": null,
+											"error": {
+												"errorCode": "FOL-400",
+												"reason": "폴더명을 1자 이상 입력해야 합니다.",
+												"data": {
+													"folderName": ""
+												}
+											}
+										}
 									}
 								}
 							}
@@ -2345,6 +2371,19 @@
 												"data": {
 													"userId": "1",
 													"folderName": "string"
+												}
+											}
+										}
+									},
+									"Example 2": {
+										"value": {
+											"resultType": "FAIL",
+											"success": null,
+											"error": {
+												"errorCode": "FOL-400",
+												"reason": "폴더명을 1자 이상 입력해야 합니다.",
+												"data": {
+													"folderName": ""
 												}
 											}
 										}


### PR DESCRIPTION
- FolderValidationError 에러 핸들링을 만들어 입력한 폴더명이 공백으로 되어있을 경우 에러 처리
  - trim()을 이용해 앞뒤 공백을 제외하여 검색어의 길이가 0일 경우 검색 에러 응답을 반환한다.